### PR TITLE
Handle all-missing input in minmax scaling

### DIFF
--- a/R/utils_format.R
+++ b/R/utils_format.R
@@ -33,6 +33,9 @@ safe_sum <- function(x) {                                   # compute sum with N
 minmax_0_100 <- function(x) {                               # rescale numeric vector to [0,100]
   if (length(x) == 0L) return(numeric())                    # empty input -> empty output
   x <- as.numeric(x)
+  if (!any(is.finite(x))) {                                 # all values missing/non-finite -> return all NA
+    return(rep(NA_real_, length(x)))
+  }
   range <- range(x, na.rm = TRUE)
   if (any(is.infinite(range))) {                            # handle degenerate case with all NA
     return(rep(NA_real_, length(x)))


### PR DESCRIPTION
## Summary
- add a guard in `minmax_0_100()` that returns all-`NA_real_` when no finite inputs exist before scaling

## Testing
- Rscript tests/test_report1.R *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68da9b795aac8328a68b52e71b16bb85