### PR TITLE
Improve schema validation and output durability

### DIFF
--- a/R/io.R
+++ b/R/io.R
@@ -17,6 +17,32 @@ suppressPackageStartupMessages({                             # ensure clean cons
   library(jsonlite)
 })
 
+.atomic_replace <- function(tmp, path, label) {              # helper to replace destination atomically with rollback
+  if (!file.exists(tmp)) {
+    stop(sprintf("%s: temporary file '%s' is missing before atomic replace.", label, tmp))
+  }
+  if (!file.exists(path)) {
+    if (!file.rename(tmp, path)) {
+      stop(sprintf("%s: failed to move temporary file into '%s'.", label, path))
+    }
+    return(invisible(path))
+  }
+  dir <- dirname(path)
+  backup <- tempfile(pattern = paste0(basename(path), ".bak."), tmpdir = dir)
+  if (!file.rename(path, backup)) {
+    unlink(tmp)
+    stop(sprintf("%s: unable to prepare atomic replacement for existing file '%s'.", label, path))
+  }
+  success <- file.rename(tmp, path)
+  if (!success) {
+    file.rename(backup, path)
+    unlink(tmp)
+    stop(sprintf("%s: failed to move temporary file into '%s'. Original file restored.", label, path))
+  }
+  unlink(backup)
+  invisible(path)
+}
+
 ensure_outdir <- function(path) {                            # create directory if missing
   if (missing(path) || !is.character(path) || length(path) != 1L || is.na(path)) {
     stop("ensure_outdir(): 'path' must be a non-NA character scalar.")
@@ -37,13 +63,7 @@ write_report_csv <- function(df, path, exclude = NULL, exclude_regex = NULL) {
   formatted <- format_dataframe(df, exclude = exclude, exclude_regex = exclude_regex)
   tmp <- tempfile(pattern = paste0(basename(path), "."), tmpdir = dir)
   readr::write_csv(formatted, tmp, na = "", quote_escape = "double")
-  if (file.exists(path) && !file.remove(path)) {
-    stop(sprintf("write_report_csv(): unable to overwrite existing file '%s'.", path))
-  }
-  if (!file.rename(tmp, path)) {
-    stop(sprintf("write_report_csv(): failed to move temporary file into '%s'.", path))
-  }
-  invisible(path)
+  .atomic_replace(tmp, path, "write_report_csv()")
 }
 
 write_summary_json <- function(x, path) {                    # JSON writer with pretty printing
@@ -54,12 +74,6 @@ write_summary_json <- function(x, path) {                    # JSON writer with 
   if (!dir.exists(dir)) ensure_outdir(dir)
   tmp <- tempfile(pattern = paste0(basename(path), "."), tmpdir = dir)
   jsonlite::write_json(x, tmp, auto_unbox = TRUE, pretty = TRUE, digits = NA)
-  if (file.exists(path) && !file.remove(path)) {
-    stop(sprintf("write_summary_json(): unable to overwrite existing file '%s'.", path))
-  }
-  if (!file.rename(tmp, path)) {
-    stop(sprintf("write_summary_json(): failed to move temporary file into '%s'.", path))
-  }
-  invisible(path)
+  .atomic_replace(tmp, path, "write_summary_json()")
 }
 

--- a/R/validate.R
+++ b/R/validate.R
@@ -36,6 +36,10 @@ validate_schema <- function(df) {                            # schema guard for 
   if (length(missing_cols) > 0L) {
     stop(sprintf("validate_schema(): missing required columns: %s.", paste(missing_cols, collapse = ", ")))
   }
+  extra_cols <- setdiff(headers, .required_cols)
+  if (length(extra_cols) > 0L) {
+    stop(sprintf("validate_schema(): unexpected extra columns present: %s.", paste(extra_cols, collapse = ", ")))
+  }
   fy <- df[["FundingYear"]]
   parsed <- suppressWarnings(readr::parse_number(fy))
   coercible <- is.na(fy) | (!is.na(parsed) & abs(parsed - round(parsed)) < 1e-6)

--- a/tests/test_clean_derive.R
+++ b/tests/test_clean_derive.R
@@ -12,6 +12,7 @@ source_module <- function(...) {
 
 source_module("R", "clean.R")
 source_module("R", "derive.R")
+source_module("R", "validate.R")
 
 library(testthat)
 library(tibble)
@@ -22,7 +23,7 @@ test_that("clean_all parses dates, money, and imputes geo conservatively", {
     MainIsland = "luzon",
     Province = c("bulacan", "bulacan", "bulacan"),
     FundingYear = c("2021", "2022.0", "2023"),
-    TypeOfWork = "Work",
+    TypeOfWork = "  mixed   CASE  ",
     StartDate = c("2021-01-01", "2021/02/01", "2021-03-05"),
     ActualCompletionDate = c("2021-01-10", "2021-02-20", "2021-04-01"),
     ApprovedBudgetForContract = c("Php 1,000.50", "2,000", "3,000"),
@@ -39,6 +40,8 @@ test_that("clean_all parses dates, money, and imputes geo conservatively", {
   expect_equal(cleaned$Longitude[2], cleaned$Longitude[1])
   expect_true(is.na(cleaned$Latitude[3]))
   expect_equal(cleaned$Longitude[3], 120)
+  expect_equal(cleaned$Contractor[1], "Acme")
+  expect_equal(cleaned$TypeOfWork[1], "mixed CASE")
 })
 
 test_that("derive_fields computes savings and delays", {
@@ -53,5 +56,23 @@ test_that("derive_fields computes savings and delays", {
   derived <- derive_fields(raw)
   expect_equal(derived$CostSavings, 10)
   expect_equal(derived$CompletionDelayDays, 10)
+})
+
+test_that("derive_fields allows negative delays and filter_years drops disallowed years", {
+  raw <- tibble(
+    Region = "A", MainIsland = "B", Province = "C", FundingYear = c(2021L, 2024L),
+    TypeOfWork = "Work", StartDate = as.Date(c("2021-01-10", "2024-02-01")),
+    ActualCompletionDate = as.Date(c("2021-01-01", "2024-01-15")),
+    ApprovedBudgetForContract = c(100, 200),
+    ContractCost = c(120, 150),
+    Contractor = "Firm", Latitude = 1, Longitude = 1
+  )
+  derived <- derive_fields(raw)
+  expect_true(any(derived$CostSavings < 0))
+  expect_true(any(derived$CompletionDelayDays < 0))
+  filtered <- filter_years(derived, 2021:2023)
+  expect_equal(unique(filtered$FundingYear), 2021L)
+  expect_error(assert_year_filter(derived, 2021:2023))
+  expect_silent(assert_year_filter(filtered, 2021:2023))
 })
 

--- a/tests/test_ingest.R
+++ b/tests/test_ingest.R
@@ -26,6 +26,13 @@ test_that("ingest rejects zero-row files", {
   expect_error(ingest_csv(tmp), "zero data rows")
 })
 
+test_that("ingest rejects truly empty files", {
+  tmp <- tempfile(fileext = ".csv")
+  on.exit(unlink(tmp), add = TRUE)
+  file.create(tmp)
+  expect_error(ingest_csv(tmp), "empty or unreadable")
+})
+
 test_that("ingest detects duplicate headers", {
   tmp <- tempfile(fileext = ".csv")
   on.exit(unlink(tmp), add = TRUE)

--- a/tests/test_io.R
+++ b/tests/test_io.R
@@ -1,0 +1,61 @@
+source_module <- function(...) {
+  rel <- file.path(...)
+  candidates <- c(file.path("..", rel), rel)
+  for (path in candidates) {
+    if (file.exists(path)) {
+      source(path, chdir = TRUE)
+      return(invisible(TRUE))
+    }
+  }
+  stop(sprintf("Unable to locate module '%s' from test.", rel))
+}
+
+source_module("R", "utils_format.R")
+source_module("R", "io.R")
+
+library(testthat)
+library(tibble)
+
+with_tempdir <- function(code) {
+  dir <- tempfile("io-test-")
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+  force(code)
+}
+
+test_that("write_report_csv formats numeric columns with commas", {
+  with_tempdir({
+    df <- tibble(Contractor = "A", NProjects = 5L, TotalCost = 1234567.891)
+    path <- file.path(dir, "report.csv")
+    write_report_csv(df, path)
+    lines <- readLines(path)
+    expect_match(lines[2], '"1,234,567.89"')
+    expect_match(lines[2], ',5,')
+  })
+})
+
+test_that("write_report_csv overwrites atomically", {
+  with_tempdir({
+    df1 <- tibble(Contractor = "A", NProjects = 5L, TotalCost = 1000)
+    df2 <- tibble(Contractor = "A", NProjects = 5L, TotalCost = 2000)
+    path <- file.path(dir, "report.csv")
+    write_report_csv(df1, path)
+    first <- readLines(path)
+    write_report_csv(df2, path)
+    second <- readLines(path)
+    expect_false(identical(first, second))
+    expect_match(second[2], '"2,000.00"')
+  })
+})
+
+test_that("write_summary_json writes pretty auto-unboxed scalars", {
+  with_tempdir({
+    payload <- list(total_projects = 10L, total_savings = 123.45)
+    path <- file.path(dir, "summary.json")
+    write_summary_json(payload, path)
+    lines <- readLines(path)
+    expect_match(lines[1], "\\{")
+    expect_true(any(grepl('"total_projects"\\s*:\\s*10', lines)))
+    expect_true(any(grepl('"total_savings"\\s*:\\s*123.45', lines)))
+  })
+})

--- a/tests/test_pipeline_integration.R
+++ b/tests/test_pipeline_integration.R
@@ -1,0 +1,85 @@
+source_module <- function(...) {
+  rel <- file.path(...)
+  candidates <- c(file.path("..", rel), rel)
+  for (path in candidates) {
+    if (file.exists(path)) {
+      source(path, chdir = TRUE)
+      return(invisible(TRUE))
+    }
+  }
+  stop(sprintf("Unable to locate module '%s' from test.", rel))
+}
+
+find_path <- function(...) {
+  rel <- file.path(...)
+  candidates <- c(file.path("..", rel), rel)
+  for (path in candidates) {
+    if (file.exists(path)) return(path)
+  }
+  stop(sprintf("Unable to locate file '%s' from test.", rel))
+}
+
+source_module("R", "utils_log.R")
+source_module("R", "utils_format.R")
+source_module("R", "io.R")
+source_module("R", "ingest.R")
+source_module("R", "validate.R")
+source_module("R", "clean.R")
+source_module("R", "derive.R")
+source_module("R", "report1.R")
+source_module("R", "report2.R")
+source_module("R", "report3.R")
+source_module("R", "summary.R")
+
+library(testthat)
+
+with_tempdir <- function(code) {
+  dir <- tempfile("pipeline-out-")
+  dir.create(dir)
+  on.exit(unlink(dir, recursive = TRUE), add = TRUE)
+  force(code)
+}
+
+test_that("tiny fixture end-to-end pipeline respects invariants", {
+  input <- find_path("sample-data", "tiny_fixture.csv")
+  df_raw <- ingest_csv(input)
+  validate_schema(df_raw)
+  df_clean <- clean_all(df_raw)
+  df_plus <- derive_fields(df_clean)
+  df_filtered <- filter_years(df_plus, 2021:2023)
+  expect_silent(assert_year_filter(df_filtered, 2021:2023))
+  expect_true(all(df_filtered$FundingYear %in% 2021:2023))
+
+  r1 <- report_regional_efficiency(df_filtered)
+  r2 <- report_contractor_ranking(df_filtered)
+  r3 <- report_overrun_trends(df_filtered)
+  sumry <- build_summary(df_filtered)
+
+  expect_true(all(r1$EfficiencyScore >= 0 & r1$EfficiencyScore <= 100, na.rm = TRUE))
+  expect_lte(nrow(r2), 15)
+  expect_true(all(r3$FundingYear == sort(r3$FundingYear)))
+  expect_true(all(is.na(r3$YoY_vs_2021[r3$FundingYear == 2021])))
+
+  with_tempdir({
+    outdir <- dir
+    f1 <- file.path(outdir, "report1_regional_efficiency.csv")
+    f2 <- file.path(outdir, "report2_top_contractors.csv")
+    f3 <- file.path(outdir, "report3_overruns_trend.csv")
+    fj <- file.path(outdir, "summary.json")
+
+    write_report_csv(r1, f1)
+    write_report_csv(r2, f2)
+    write_report_csv(r3, f3)
+    write_summary_json(sumry, fj)
+
+    expect_true(file.exists(f1))
+    expect_true(file.exists(f2))
+    expect_true(file.exists(f3))
+    expect_true(file.exists(fj))
+
+    lines1 <- readLines(f1)
+    expect_match(lines1[2], '"')
+    json <- readLines(fj)
+    expect_true(any(grepl('"total_projects"', json)))
+  })
+})

--- a/tests/test_report1.R
+++ b/tests/test_report1.R
@@ -32,3 +32,19 @@ test_that("report 1 computes efficiency metrics within bounds", {
   expect_equal(report$Delay30Rate, c(100, 0))
 })
 
+test_that("report 1 handles all-NA groups without crashing", {
+  df <- tibble(
+    Region = c("Region C", "Region C"),
+    MainIsland = c("Island 3", "Island 3"),
+    ApprovedBudgetForContract = c(NA_real_, NA_real_),
+    ContractCost = c(NA_real_, NA_real_),
+    CostSavings = c(NA_real_, NA_real_),
+    CompletionDelayDays = c(NA_real_, NA_real_)
+  )
+  report <- report_regional_efficiency(df)
+  expect_true(all(is.na(report$MedianSavings)))
+  expect_true(all(is.na(report$AvgDelay)))
+  expect_true(all(is.na(report$Delay30Rate)))
+  expect_true(all(is.na(report$EfficiencyScore)))
+})
+

--- a/tests/test_report2.R
+++ b/tests/test_report2.R
@@ -44,3 +44,16 @@ test_that("report 2 enforces eligibility and ranking rules", {
   expect_equal(risk, "High Risk")
 })
 
+test_that("report 2 applies the NProjects threshold correctly", {
+  df <- dplyr::bind_rows(
+    make_contractor("Firm 4", n = 4),
+    make_contractor("Firm 5", n = 5, cost = 200, savings = 100, delay = -10),
+    make_contractor("Firm 6", n = 6, cost = 150, savings = 20, delay = 5)
+  )
+  report <- report_contractor_ranking(df)
+  expect_false("Firm 4" %in% report$Contractor)
+  expect_true("Firm 5" %in% report$Contractor)
+  expect_true("Firm 6" %in% report$Contractor)
+  expect_true(all(report$ReliabilityIndex <= 100, na.rm = TRUE))
+})
+

--- a/tests/test_report3.R
+++ b/tests/test_report3.R
@@ -30,3 +30,15 @@ test_that("report 3 applies baseline logic correctly", {
   expect_equal(report$FundingYear, sort(report$FundingYear))
 })
 
+test_that("report 3 survives all-NA savings groups", {
+  df <- tibble(
+    FundingYear = c(2021L, 2022L),
+    TypeOfWork = c("Type C", "Type C"),
+    CostSavings = c(NA_real_, NA_real_)
+  )
+  report <- report_overrun_trends(df)
+  expect_true(all(is.na(report$AvgSavings)))
+  expect_true(all(is.na(report$OverrunRate)))
+  expect_true(all(is.na(report$YoY_vs_2021)))
+})
+

--- a/tests/test_validate.R
+++ b/tests/test_validate.R
@@ -20,6 +20,17 @@ test_that("validate_schema detects missing columns", {
   expect_error(validate_schema(df), "missing required columns")
 })
 
+test_that("validate_schema rejects unexpected columns", {
+  df <- tibble(
+    Region = "NCR", MainIsland = "Luzon", Province = "Metro Manila",
+    FundingYear = 2021, TypeOfWork = "Work", StartDate = "2021-01-01",
+    ActualCompletionDate = "2021-02-01", ApprovedBudgetForContract = 1,
+    ContractCost = 1, Contractor = "A", Latitude = 1, Longitude = 1,
+    ExtraColumn = 123
+  )
+  expect_error(validate_schema(df), "unexpected extra columns")
+})
+
 test_that("validate_schema enforces integer-like FundingYear", {
   df <- tibble(
     Region = "NCR", MainIsland = "Luzon", Province = "Metro Manila",


### PR DESCRIPTION
## Summary
- enforce exact column matching in `validate_schema()` and cover it with new unit tests
- harden report writers with rollback-safe atomic replacement helpers
- extend the test suite with IO checks, pipeline integration coverage, and additional edge cases across modules

## Testing
- not run (R binary unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68daa4360040832896e182362f57fccb