### PR TITLE
Fix validate schema brace error and canonicalize coordinates

### DIFF
--- a/R/clean.R
+++ b/R/clean.R
@@ -97,6 +97,20 @@ clean_all <- function(df) {                                                # def
     Lon = sum(is.na(df[["Longitude"]]))                                    # NA count in Longitude
   )
 
+  # ---- Canonicalize coordinate column names (accept synonyms) ----------------
+  # If Latitude/Longitude are absent but ProjectLatitude/ProjectLongitude exist,
+  # rename the latter to the canonical names so all downstream steps use one pair.
+  if (!('Latitude' %in% names(df)) && all(c('ProjectLatitude','ProjectLongitude') %in% names(df))) {
+    if (all(c('Latitude','Longitude') %in% names(df))) {
+      if (exists('log_warn', mode = 'function')) {
+        log_warn('Both coordinate pairs present; using canonical Latitude/Longitude; ignoring ProjectLatitude/ProjectLongitude.')
+      }
+    } else {
+      names(df)[match('ProjectLatitude', names(df))]  <- 'Latitude'
+      names(df)[match('ProjectLongitude', names(df))] <- 'Longitude'
+    }
+  }
+
   # ---- Type coercions & text normalization (idempotent) ----------------------
   df1 <- df %>%                                                            # start a new pipeline to avoid surprise mutation
     mutate(

--- a/R/validate.R
+++ b/R/validate.R
@@ -2,13 +2,79 @@
 # ------------------------------------------------------------------------------
 # Purpose : Schema/type/invariant checks for the DPWH flood-control CSV.
 # Contract: validate_schema(df) -> invisible(TRUE) or stop() on violations
+#           assert_year_filter(df, allowed_years=2021:2023) -> invisible(TRUE)
+# Notes   : Accepts either {Latitude,Longitude} OR {ProjectLatitude,ProjectLongitude}.
+#           No value transformations here; only structure/invariants.
+# ------------------------------------------------------------------------------
 
+# Helper: does ANY pair in a matrix of pairs exist fully in `nms`? ------------
+.has_pair <- function(nms, pairs) {
+  any(apply(pairs, 1L, function(p) all(p %in% nms)))
+}
+
+#' Validate the raw schema (presence, duplicates, non-empty).
+#' @param df data.frame/tibble read by ingest_csv().
+#' @return invisible(TRUE) if valid; otherwise stop() with a precise message.
+validate_schema <- function(df) {
+  if (missing(df) || !is.data.frame(df)) {
+    stop("validate_schema(): 'df' must be a data.frame/tibble from ingest_csv().")
+  }
+
+  nms <- names(df)
+  if (length(nms) == 0L) {
+    stop("validate_schema(): dataframe has zero columns.")
+  }
+  if (nrow(df) == 0L) {
+    stop("validate_schema(): dataframe has zero rows (no data).")
+  }
+
+  # No duplicated headers
+  dups <- nms[duplicated(nms)]
+  if (length(dups) > 0L) {
+    stop(sprintf("validate_schema(): duplicated column names: %s.", paste(sort(unique(dups)), collapse = ", ")))
+  }
+
+  # Strict required columns (excluding coordinates, which accept synonyms)
+  required_strict <- c(
+    "Region","MainIsland","Province","FundingYear","TypeOfWork",
+    "StartDate","ActualCompletionDate","ApprovedBudgetForContract",
+    "ContractCost","Contractor"
+  )
+  missing_strict <- setdiff(required_strict, nms)
+  if (length(missing_strict) > 0L) {
+    stop(sprintf("validate_schema(): missing required columns: %s.", paste(missing_strict, collapse = ", ")))
+  }
+
+  # Coordinates: accept canonical OR synonyms; fail only if neither pair exists
+  latlon_pairs <- rbind(
+    c("Latitude","Longitude"),
+    c("ProjectLatitude","ProjectLongitude")
+  )
+  if (!.has_pair(nms, latlon_pairs)) {
+    stop("validate_schema(): missing coordinates; expected either {Latitude,Longitude} or {ProjectLatitude,ProjectLongitude}.")
   }
 
   invisible(TRUE)
 }
 
-
+#' Assert that all FundingYear values are within the allowed set (post-filter).
+#' @param df data.frame with FundingYear present.
+#' @param allowed_years integer vector of allowed years (default 2021:2023).
+#' @return invisible(TRUE) or stop() listing offending values.
+assert_year_filter <- function(df, allowed_years = 2021:2023) {
+  if (missing(df) || !is.data.frame(df)) {
+    stop("assert_year_filter(): 'df' must be a data.frame/tibble.")
+  }
+  if (!"FundingYear" %in% names(df)) {
+    stop("assert_year_filter(): 'FundingYear' column is missing.")
+  }
+  vals <- unique(stats::na.omit(df$FundingYear))
+  bad  <- setdiff(vals, allowed_years)
+  if (length(bad) > 0L) {
+    stop(sprintf(
+      "assert_year_filter(): found disallowed FundingYear values: %s; allowed: %s.",
+      paste(sort(bad), collapse = ", "), paste(allowed_years, collapse = ", ")
+    ))
   }
   invisible(TRUE)
 }

--- a/tests/test_clean_derive.R
+++ b/tests/test_clean_derive.R
@@ -44,6 +44,21 @@ test_that("clean_all parses dates, money, and imputes geo conservatively", {
   expect_equal(cleaned$TypeOfWork[1], "mixed CASE")
 })
 
+test_that("clean_all canonicalizes ProjectLatitude/ProjectLongitude", {
+  raw <- data.frame(
+    Region = "NCR", MainIsland = "Luzon", Province = "Metro Manila", FundingYear = "2021",
+    TypeOfWork = "Dredging", StartDate = "2021-01-01", ActualCompletionDate = "2021-01-10",
+    ApprovedBudgetForContract = "1,000,000", ContractCost = "900,000", Contractor = "ABC",
+    ProjectLatitude = "14.600", ProjectLongitude = "121.000",
+    check.names = FALSE
+  )
+  validate_schema(raw)
+  out <- clean_all(raw)
+  expect_true(all(c("Latitude","Longitude") %in% names(out)))
+  expect_false(any(c("ProjectLatitude","ProjectLongitude") %in% names(out)))
+  expect_true(is.numeric(out$Latitude) && is.numeric(out$Longitude))
+})
+
 test_that("derive_fields computes savings and delays", {
   raw <- tibble(
     Region = "A", MainIsland = "B", Province = "C", FundingYear = 2021L,

--- a/tests/test_validate.R
+++ b/tests/test_validate.R
@@ -20,12 +20,24 @@ test_that("validate_schema detects missing columns", {
   expect_error(validate_schema(df), "missing required columns")
 })
 
-
+test_that("validate_schema accepts coordinate synonyms", {
   df <- data.frame(
     Region = "NCR", MainIsland = "Luzon", Province = "Metro Manila", FundingYear = 2021,
     TypeOfWork = "Dredging", StartDate = "2021-01-01", ActualCompletionDate = "2021-01-10",
     ApprovedBudgetForContract = 1, ContractCost = 0.9, Contractor = "ABC",
+    ProjectLatitude = 14.6, ProjectLongitude = 121.0,
+    check.names = FALSE
+  )
+  expect_silent(validate_schema(df))
+})
 
+test_that("validate_schema fails if neither coordinate pair exists", {
+  df <- data.frame(
+    Region = "NCR", MainIsland = "Luzon", Province = "Metro Manila", FundingYear = 2021,
+    TypeOfWork = "Dredging", StartDate = "2021-01-01", ActualCompletionDate = "2021-01-10",
+    ApprovedBudgetForContract = 1, ContractCost = 0.9, Contractor = "ABC",
+    check.names = FALSE
+  )
   expect_error(validate_schema(df), "missing coordinates")
 })
 
@@ -33,4 +45,3 @@ test_that("assert_year_filter detects unexpected years", {
   df <- tibble(FundingYear = c(2021L, 2024L))
   expect_error(assert_year_filter(df, 2021:2023), "found disallowed FundingYear")
 })
-


### PR DESCRIPTION
## Summary
- replace the broken validate.R implementation with a brace-balanced version that accepts either Latitude/Longitude or ProjectLatitude/ProjectLongitude
- canonicalize coordinate column names inside clean_all() so downstream logic always works with the Latitude/Longitude pair
- extend validate and clean tests to cover coordinate synonym acceptance and canonicalization

## Testing
- not run (Rscript unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dab76468c483288aadc4550a995bd9