### PR TITLE
fix: harden clean logging and add NA delta smoke test

### DIFF
--- a/tests/test_clean_derive.R
+++ b/tests/test_clean_derive.R
@@ -91,5 +91,24 @@ test_that("derive_fields allows negative delays and filter_years drops disallowe
   expect_silent(assert_year_filter(filtered, 2021:2023))
 })
 
+test_that("NA delta logging computes per-column integer deltas without error", {
+  raw <- data.frame(
+    Region = c("NCR", NA), MainIsland = c("Luzon", "Luzon"),
+    Province = c("Metro Manila", "Metro Manila"), FundingYear = c("2021", "2021"),
+    TypeOfWork = c("Dredging", "Dredging"),
+    StartDate = c("2021-01-01", NA), ActualCompletionDate = c("2021-01-10", "2021-01-20"),
+    ApprovedBudgetForContract = c("1,000,000", "2,000,000"),
+    ContractCost = c("900,000", "1,900,000"),
+    Contractor = c("ABC", "ABC"),
+    ProjectLatitude = c("14.6", NA), ProjectLongitude = c("121.0", NA),
+    check.names = FALSE
+  )
+  validate_schema(raw)
+  cols_track <- c("Region","MainIsland","Province","FundingYear","TypeOfWork","StartDate","ActualCompletionDate",
+                  "ApprovedBudgetForContract","ContractCost","Contractor","Latitude","Longitude")
+  out <- clean_all(raw)
+  expect_true(is.data.frame(out))
+})
+
 
 


### PR DESCRIPTION
## Summary
- validate `clean_all()` inputs, retain canonicalized coordinate order, and replace the NA delta logging with a vectorised implementation that avoids trailing commas
- document keeping coordinate canonicalisation ahead of type coercions for consistent NA tracking
- add a smoke test covering the NA delta logging path

## Testing
- Rscript -e "source('R/clean.R'); cat('clean.R parsed OK\\n')" *(fails: Rscript is unavailable in the container)*
- Rscript -e "for(f in list.files('R', full.names=TRUE)){source(f);cat('OK ',basename(f),'\\n')}" *(fails: Rscript is unavailable in the container)*
- Rscript main.R --input "dpwh_flood_control_projects.csv" --outdir outputs *(fails: Rscript is unavailable in the container)*
- dir outputs *(fails: outputs directory not created because the pipeline was not executed)*
- type outputs\summary.json *(fails: `type` in bash reports missing command/file as the pipeline did not run)*
- Rscript -e "x<-readr::read_csv('outputs/report1_regional_efficiency.csv', show_col_types=FALSE); stopifnot(all(x$EfficiencyScore>=0 & x$EfficiencyScore<=100, na.rm=TRUE))" *(fails: Rscript is unavailable in the container)*
- Rscript -e "x<-readr::read_csv('outputs/report2_top_contractors.csv', show_col_types=FALSE); stopifnot(nrow(x)<=15)" *(fails: Rscript is unavailable in the container)*
- R -q -e "testthat::test_dir('tests')" *(fails: R is unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68db27c612a483289e060155921747a6