### PR TITLE
Fix FundingYear coercion to handle non-character inputs

### DIFF
--- a/tests/test_clean_derive.R
+++ b/tests/test_clean_derive.R
@@ -110,5 +110,20 @@ test_that("NA delta logging computes per-column integer deltas without error", {
   expect_true(is.data.frame(out))
 })
 
+test_that("FundingYear coercion accepts numeric, character, and factor", {
+  source("R/clean.R")  # ensure helper is visible in test
+  raw_num <- data.frame(FundingYear = c(2021, 2022, NA_real_), check.names = FALSE)
+  raw_chr <- data.frame(FundingYear = c("2021", " 2022 ", "NA"), check.names = FALSE)
+  raw_fac <- data.frame(FundingYear = factor(c("2023","2021",NA)), check.names = FALSE)
+
+  out_num <- .as_integer_safely(raw_num$FundingYear)
+  out_chr <- .as_integer_safely(raw_chr$FundingYear)
+  out_fac <- .as_integer_safely(raw_fac$FundingYear)
+
+  expect_identical(out_num, as.integer(c(2021, 2022, NA)))
+  expect_identical(out_chr, as.integer(c(2021, 2022, NA)))
+  expect_identical(out_fac, as.integer(c(2023, 2021, NA)))
+})
+
 
 


### PR DESCRIPTION
## Summary
- harden `.as_integer_safely()` so it handles integer, numeric, character, and factor inputs without calling `readr::parse_integer()` on non-character data
- ensure `clean_all()` uses the helper via `.data$FundingYear`
- add unit coverage asserting FundingYear coercion works for numeric, character, and factor vectors

## Testing
- `Rscript -e "source('R/clean.R'); cat('clean.R parsed OK\n')"` *(fails: Rscript not available in container)*
- `R -q -e "testthat::test_dir('tests')"` *(fails: R executable not available in container)*
- `Rscript main.R --input "dpwh_flood_control_projects.csv" --outdir outputs` *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db38220e10832895f9966ee42016b5