### PR TITLE
Add readr write compatibility shim for CSV reports

### DIFF
--- a/tests/test_io.R
+++ b/tests/test_io.R
@@ -59,3 +59,14 @@ test_that("write_summary_json writes pretty auto-unboxed scalars", {
     expect_true(any(grepl('"total_savings"\\s*:\\s*123.45', lines)))
   })
 })
+
+test_that("write_csv_compat works with current readr", {
+  source("R/io.R")
+  df <- data.frame(a = c(1, 2), b = c('x', 'y'))
+  tmp <- tempfile(fileext = ".csv")
+  on.exit(unlink(tmp), add = TRUE)
+  expect_silent(write_csv_compat(df, file = tmp, na = "", col_names = TRUE, delim = ",", progress = FALSE))
+  back <- readr::read_csv(tmp, show_col_types = FALSE)
+  expect_equal(nrow(back), 2L)
+  expect_true(all(names(back) == c("a","b")))
+})


### PR DESCRIPTION
## Summary
- add a readr version shim in `write_csv_compat` that uses `escape` on readr >= 2.0 and falls back to `quote_escape`
- route `write_report_csv` through the compatibility helper while preserving atomic writes and formatting helpers
- add a smoke test to exercise `write_csv_compat` against the installed readr

## Testing
- `Rscript -e "source('R/io.R'); cat('io.R parsed OK\n')"` *(fails: `Rscript` not available in container)*
- `Rscript -e "for(f in list.files('R', full.names=TRUE)){source(f);cat('OK ',basename(f),'\n')}"` *(fails: `Rscript` not available in container)*
- `Rscript main.R --input "dpwh_flood_control_projects.csv" --outdir outputs` *(fails: `Rscript` not available in container)*
- `R -q -e "testthat::test_dir('tests')"` *(fails: `R` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db41fba0ac83288bb586f8e59a423d