### PR TITLE
fix: harden money parsing and guard savings aggregation

### DIFF
--- a/tests/test_clean_derive.R
+++ b/tests/test_clean_derive.R
@@ -125,5 +125,20 @@ test_that("FundingYear coercion accepts numeric, character, and factor", {
   expect_identical(out_fac, as.integer(c(2023, 2021, NA)))
 })
 
+test_that("parse money handles Php, commas, M/B suffix, and clamps absurd values", {
+  source("R/clean.R")
+
+  x <- c("Php 1,234,567.89", "2,000,000", "500M", "1.2B", "9999999999999", "NA", "garbage")
+  y <- .parse_money_safely(x)
+
+  expect_equal(y[1], 1234567.89, tolerance = 1e-6)
+  expect_equal(y[2], 2000000)
+  expect_equal(y[3], 500e6)
+  expect_equal(y[4], 1.2e9)
+  expect_true(is.na(y[5]))
+  expect_true(is.na(y[6]))
+  expect_true(is.na(y[7]))
+})
+
 
 

--- a/tests/test_summary.R
+++ b/tests/test_summary.R
@@ -31,3 +31,14 @@ test_that("summary aggregates scalar metrics", {
   expect_equal(payload$total_savings, 250)
 })
 
+test_that("summary total_savings is finite or NA but never absurd", {
+  df <- tibble(
+    Contractor = rep("C", 1001),
+    Province = rep("P", 1001),
+    CompletionDelayDays = rep(NA_real_, 1001),
+    CostSavings = c(rep(1e6, 1000), 1e146)
+  )
+  payload <- build_summary(df)
+  expect_true(is.na(payload$total_savings) || abs(payload$total_savings) <= 1e13)
+})
+


### PR DESCRIPTION
## Summary
- replace the currency parser with a stricter helper that normalizes Php strings, supports M/B suffixes, clamps >1e12 entries, and logs ranges/maxima
- guard derived CostSavings and summary totals by zeroing implausible or non-finite magnitudes to prevent runaway aggregates
- add regression tests covering money parsing edge cases and summary total sanity checks

## Testing
- Rscript -e "testthat::test_dir('tests')" *(fails: Rscript not available in container)*


------
https://chatgpt.com/codex/tasks/task_e_68db646e04848328b7bca0bcb8773520