### PR TITLE
Harden schema validation and add regression tests

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -7,6 +7,21 @@
 #           No value transformations here; only structure/invariants.
 # ------------------------------------------------------------------------------
 
+# Helper: assert data.frame-like inputs ---------------------------------------
+assert_is_df <- function(x, var = deparse(substitute(x))) {
+  if (!is.data.frame(x)) {
+    stop(
+      sprintf(
+        "assert_is_df(): '%s' is not a data.frame/tibble (class: %s).",
+        var,
+        paste(class(x), collapse = "/")
+      ),
+      call. = FALSE
+    )
+  }
+  invisible(TRUE)
+}
+
 # Helper: does ANY pair in a matrix of pairs exist fully in `nms`? ------------
 .has_pair <- function(nms, pairs) {
   any(apply(pairs, 1L, function(p) all(p %in% nms)))
@@ -16,42 +31,67 @@
 #' @param df data.frame/tibble read by ingest_csv().
 #' @return invisible(TRUE) if valid; otherwise stop() with a precise message.
 validate_schema <- function(df) {
-  if (missing(df) || !is.data.frame(df)) {
-    stop("validate_schema(): 'df' must be a data.frame/tibble from ingest_csv().")
+  if (missing(df)) {
+    stop("validate_schema(): argument 'df' is missing.", call. = FALSE)
   }
+
+  # Unwrap a common {data=..., problems=...} list shape -----------------------
+  if (is.list(df) && !is.data.frame(df) && !is.null(df$data)) {
+    df <- df$data
+  }
+
+  assert_is_df(df, var = "df")
 
   nms <- names(df)
   if (length(nms) == 0L) {
-    stop("validate_schema(): dataframe has zero columns.")
-  }
-  if (nrow(df) == 0L) {
-    stop("validate_schema(): dataframe has zero rows (no data).")
+    stop("validate_schema(): input has zero columns.", call. = FALSE)
   }
 
-  # No duplicated headers
+  if (nrow(df) == 0L) {
+    stop("validate_schema(): input has zero rows.", call. = FALSE)
+  }
+
+  # No duplicated headers -----------------------------------------------------
   dups <- nms[duplicated(nms)]
   if (length(dups) > 0L) {
-    stop(sprintf("validate_schema(): duplicated column names: %s.", paste(sort(unique(dups)), collapse = ", ")))
+    stop(
+      sprintf(
+        "validate_schema(): duplicated column names: %s.",
+        paste(sort(unique(dups)), collapse = ", ")
+      ),
+      call. = FALSE
+    )
   }
 
-  # Strict required columns (excluding coordinates, which accept synonyms)
+  # Strict required columns (excluding coordinates, which accept synonyms) ----
   required_strict <- c(
-    "Region","MainIsland","Province","FundingYear","TypeOfWork",
-    "StartDate","ActualCompletionDate","ApprovedBudgetForContract",
-    "ContractCost","Contractor"
+    "Region", "MainIsland", "Province",
+    "FundingYear", "TypeOfWork",
+    "StartDate", "ActualCompletionDate",
+    "ApprovedBudgetForContract", "ContractCost",
+    "Contractor"
   )
   missing_strict <- setdiff(required_strict, nms)
   if (length(missing_strict) > 0L) {
-    stop(sprintf("validate_schema(): missing required columns: %s.", paste(missing_strict, collapse = ", ")))
+    stop(
+      sprintf(
+        "validate_schema(): missing required columns: %s.",
+        paste(missing_strict, collapse = ", ")
+      ),
+      call. = FALSE
+    )
   }
 
   # Coordinates: accept canonical OR synonyms; fail only if neither pair exists
   latlon_pairs <- rbind(
-    c("Latitude","Longitude"),
-    c("ProjectLatitude","ProjectLongitude")
+    c("Latitude", "Longitude"),
+    c("ProjectLatitude", "ProjectLongitude")
   )
   if (!.has_pair(nms, latlon_pairs)) {
-    stop("validate_schema(): missing coordinates; expected either {Latitude,Longitude} or {ProjectLatitude,ProjectLongitude}.")
+    stop(
+      "validate_schema(): missing coordinates; expected either {Latitude,Longitude} or {ProjectLatitude,ProjectLongitude}.",
+      call. = FALSE
+    )
   }
 
   invisible(TRUE)
@@ -62,11 +102,12 @@ validate_schema <- function(df) {
 #' @param allowed_years integer vector of allowed years (default 2021:2023).
 #' @return invisible(TRUE) or stop() listing offending values.
 assert_year_filter <- function(df, allowed_years = 2021:2023) {
-  if (missing(df) || !is.data.frame(df)) {
-    stop("assert_year_filter(): 'df' must be a data.frame/tibble.")
+  if (missing(df)) {
+    stop("assert_year_filter(): argument 'df' is missing.", call. = FALSE)
   }
+  assert_is_df(df, var = "df")
   if (!"FundingYear" %in% names(df)) {
-    stop("assert_year_filter(): 'FundingYear' column is missing.")
+    stop("assert_year_filter(): 'FundingYear' column is missing.", call. = FALSE)
   }
   vals <- unique(stats::na.omit(df$FundingYear))
   bad  <- setdiff(vals, allowed_years)
@@ -74,7 +115,7 @@ assert_year_filter <- function(df, allowed_years = 2021:2023) {
     stop(sprintf(
       "assert_year_filter(): found disallowed FundingYear values: %s; allowed: %s.",
       paste(sort(bad), collapse = ", "), paste(allowed_years, collapse = ", ")
-    ))
+    ), call. = FALSE)
   }
   invisible(TRUE)
 }

--- a/main.R
+++ b/main.R
@@ -61,6 +61,12 @@ suppressPackageStartupMessages({                            # suppress package b
   with_log_context(list(stage = "ingest"), {
     df_raw <<- ingest_csv(args$input)
     rows_loaded <<- nrow(df_raw)
+    log_info(
+      "diagnostic: class(raw)=%s; nrow=%s; names[1:5]=%s",
+      paste(class(df_raw), collapse = "/"),
+      NROW(df_raw),
+      paste(utils::head(names(df_raw), 5), collapse = ",")
+    )
   })
 
   with_log_context(list(stage = "validate"), {

--- a/tests/test_main_contract.R
+++ b/tests/test_main_contract.R
@@ -1,0 +1,31 @@
+source_module <- function(...) {
+  rel <- file.path(...)
+  candidates <- c(file.path("..", rel), rel)
+  for (path in candidates) {
+    if (file.exists(path)) {
+      source(path, chdir = TRUE)
+      return(invisible(TRUE))
+    }
+  }
+  stop(sprintf("Unable to locate module '%s' from test.", rel))
+}
+
+source_module("R", "ingest.R")
+source_module("R", "validate.R")
+source_module("R", "clean.R")
+
+library(testthat)
+
+csv_path <- if (file.exists("dpwh_flood_control_projects.csv")) {
+  "dpwh_flood_control_projects.csv"
+} else {
+  file.path("..", "dpwh_flood_control_projects.csv")
+}
+
+test_that("main pipeline hooks: ingest -> validate -> clean", {
+  x <- ingest_csv(csv_path)
+  expect_silent(validate_schema(x))
+  y <- clean_all(x)
+  expect_true(is.data.frame(y))
+  expect_gt(nrow(y), 0)
+})

--- a/tests/test_validate.R
+++ b/tests/test_validate.R
@@ -10,10 +10,24 @@ source_module <- function(...) {
   stop(sprintf("Unable to locate module '%s' from test.", rel))
 }
 
+source_module("R", "ingest.R")
 source_module("R", "validate.R")
 
 library(testthat)
 library(tibble)
+
+csv_path <- if (file.exists("dpwh_flood_control_projects.csv")) {
+  "dpwh_flood_control_projects.csv"
+} else {
+  file.path("..", "dpwh_flood_control_projects.csv")
+}
+
+test_that("validate_schema accepts tibble from ingest and rejects wrong shapes", {
+  x <- ingest_csv(csv_path)
+  expect_silent(validate_schema(x))
+  expect_error(validate_schema(list(foo = 1)), "data.frame/tibble")
+  expect_error(validate_schema(list(data = 1:3)), "data.frame/tibble")
+})
 
 test_that("validate_schema detects missing columns", {
   df <- tibble(Region = "NCR", FundingYear = 2021)
@@ -39,6 +53,16 @@ test_that("validate_schema fails if neither coordinate pair exists", {
     check.names = FALSE
   )
   expect_error(validate_schema(df), "missing coordinates")
+})
+
+test_that("validate_schema unwraps list$data shape", {
+  df <- tibble(
+    Region = "NCR", MainIsland = "Luzon", Province = "Metro Manila", FundingYear = 2021,
+    TypeOfWork = "Dredging", StartDate = "2021-01-01", ActualCompletionDate = "2021-01-10",
+    ApprovedBudgetForContract = 1, ContractCost = 0.9, Contractor = "ABC",
+    Latitude = 14.6, Longitude = 121.0
+  )
+  expect_silent(validate_schema(list(data = df)))
 })
 
 test_that("assert_year_filter detects unexpected years", {


### PR DESCRIPTION
## Summary
- add a reusable assert helper and allow validate_schema() to unwrap nested list payloads
- tighten ingest diagnostics in the pipeline and reuse the helper in year filtering
- expand schema validation unit tests and add a contract test covering ingest -> validate -> clean

## Testing
- R -q -e "testthat::test_dir('tests')" *(fails: command not found: R)*

------
https://chatgpt.com/codex/tasks/task_e_68dba959c0748328a064fef1c1e63777