### PR TITLE
Prevent logging calls from clobbering pipeline data

### DIFF
--- a/R/clean.R
+++ b/R/clean.R
@@ -30,12 +30,14 @@ suppressPackageStartupMessages({                                           # sup
   msg <- sprintf(fmt, ...)                                                 # format message once
   if (exists("log_info", mode = "function")) log_info("%s", msg)            # delegate to project logger if available
   else message(sprintf("[INFO]  %s", msg))                                 # otherwise print standardized INFO line
+  invisible(NULL)
 }
 
 .log_warn <- function(fmt, ...) {                                          # define warning logger (printf-style)
   msg <- sprintf(fmt, ...)                                                 # format message once
   if (exists("log_warn", mode = "function")) log_warn("%s", msg)            # delegate to project logger if available
   else message(sprintf("[WARN]  %s", msg))                                 # otherwise print standardized WARN line
+  invisible(NULL)
 }
 
 # ----------------------------- Helper functions -------------------------------

--- a/R/derive.R
+++ b/R/derive.R
@@ -17,6 +17,7 @@ suppressPackageStartupMessages({                             # quiet load
 .log_info <- function(fmt, ...) {                            # local logging shim (delegates when global logger exists)
   msg <- sprintf(fmt, ...)
   if (exists("log_info", mode = "function")) log_info("%s", msg) else message(sprintf("[INFO]  %s", msg))
+  invisible(NULL)
 }
 
 derive_fields <- function(df) {                              # append CostSavings + CompletionDelayDays

--- a/R/ingest.R
+++ b/R/ingest.R
@@ -37,6 +37,7 @@ ALLOW_BOM <- TRUE  # boolean; informational only (readr::read_csv strips BOM saf
   } else {                                                               # otherwise fallback to base message
     message(sprintf("[INFO]  %s", msg))                                  # print standardized info log
   }
+  invisible(NULL)
 }
 
 # Emit a warning message; integrates with project logger if present.
@@ -47,6 +48,7 @@ ALLOW_BOM <- TRUE  # boolean; informational only (readr::read_csv strips BOM saf
   } else {                                                               # otherwise fallback to base message
     message(sprintf("[WARN]  %s", msg))                                  # print standardized warn log
   }
+  invisible(NULL)
 }
 
 # ------------------------------- Public API -----------------------------------

--- a/main.R
+++ b/main.R
@@ -67,6 +67,7 @@ suppressPackageStartupMessages({                            # suppress package b
       NROW(df_raw),
       paste(utils::head(names(df_raw), 5), collapse = ",")
     )
+    stopifnot(is.data.frame(df_raw), nrow(df_raw) > 0)
   })
 
   with_log_context(list(stage = "validate"), {

--- a/tests/test_pipeline_wiring.R
+++ b/tests/test_pipeline_wiring.R
@@ -1,0 +1,19 @@
+test_that("main pipeline does not clobber data frames via logging", {
+  source("R/ingest.R")
+  source("R/validate.R")
+  source("R/clean.R")
+  source("R/derive.R")
+
+  raw <- ingest_csv("dpwh_flood_control_projects.csv")
+  expect_true(is.data.frame(raw))
+  expect_gt(nrow(raw), 0)
+
+  .log_info("class=%s n=%s", paste(class(raw), collapse = "/"), nrow(raw))
+  expect_true(is.data.frame(raw))
+
+  validate_schema(raw)
+  cleaned  <- clean_all(raw)
+  derived  <- derive_fields(cleaned)
+  expect_true(is.data.frame(derived))
+  expect_gt(nrow(derived), 0)
+})


### PR DESCRIPTION
## Summary
- add an ingest guard to stop when the raw table is not a non-empty data frame
- make module-level logging helpers explicitly return `invisible(NULL)` so assignments cannot capture output
- add a wiring regression test to ensure logging does not overwrite pipeline data frames

## Testing
- `Rscript -e "testthat::test_dir('tests')"` *(fails: Rscript command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbb5f87c90832897d878217849cb20