### PR TITLE
Prevent logging from clobbering pipeline data

### DIFF
--- a/R/clean.R
+++ b/R/clean.R
@@ -30,14 +30,14 @@ suppressPackageStartupMessages({                                           # sup
   msg <- sprintf(fmt, ...)                                                 # format message once
   if (exists("log_info", mode = "function")) log_info("%s", msg)            # delegate to project logger if available
   else message(sprintf("[INFO]  %s", msg))                                 # otherwise print standardized INFO line
-  invisible(NULL)
+  return(invisible(NULL))
 }
 
 .log_warn <- function(fmt, ...) {                                          # define warning logger (printf-style)
   msg <- sprintf(fmt, ...)                                                 # format message once
   if (exists("log_warn", mode = "function")) log_warn("%s", msg)            # delegate to project logger if available
   else message(sprintf("[WARN]  %s", msg))                                 # otherwise print standardized WARN line
-  invisible(NULL)
+  return(invisible(NULL))
 }
 
 # ----------------------------- Helper functions -------------------------------

--- a/R/derive.R
+++ b/R/derive.R
@@ -17,7 +17,7 @@ suppressPackageStartupMessages({                             # quiet load
 .log_info <- function(fmt, ...) {                            # local logging shim (delegates when global logger exists)
   msg <- sprintf(fmt, ...)
   if (exists("log_info", mode = "function")) log_info("%s", msg) else message(sprintf("[INFO]  %s", msg))
-  invisible(NULL)
+  return(invisible(NULL))
 }
 
 derive_fields <- function(df) {                              # append CostSavings + CompletionDelayDays

--- a/R/ingest.R
+++ b/R/ingest.R
@@ -37,7 +37,7 @@ ALLOW_BOM <- TRUE  # boolean; informational only (readr::read_csv strips BOM saf
   } else {                                                               # otherwise fallback to base message
     message(sprintf("[INFO]  %s", msg))                                  # print standardized info log
   }
-  invisible(NULL)
+  return(invisible(NULL))
 }
 
 # Emit a warning message; integrates with project logger if present.
@@ -48,7 +48,7 @@ ALLOW_BOM <- TRUE  # boolean; informational only (readr::read_csv strips BOM saf
   } else {                                                               # otherwise fallback to base message
     message(sprintf("[WARN]  %s", msg))                                  # print standardized warn log
   }
-  invisible(NULL)
+  return(invisible(NULL))
 }
 
 # ------------------------------- Public API -----------------------------------

--- a/R/utils_log.R
+++ b/R/utils_log.R
@@ -67,7 +67,7 @@
   if (!is.null(.log_state$file)) {                          # also persist to file when configured
     cat(line, "\n", file = .log_state$file, append = TRUE)
   }
-  invisible(NULL)
+  return(invisible(NULL))
 }
 
 # Format the payload using printf-like semantics (handles zero-argument case).
@@ -130,28 +130,28 @@ log_debug <- function(fmt, ...) {                           # emit DEBUG-level m
   if (.should_emit("DEBUG")) {
     .emit_line("DEBUG", .format_message(fmt, ...))
   }
-  invisible(NULL)
+  return(invisible(NULL))
 }
 
 log_info <- function(fmt, ...) {                            # emit INFO-level message if allowed
   if (.should_emit("INFO")) {
     .emit_line("INFO", .format_message(fmt, ...))
   }
-  invisible(NULL)
+  return(invisible(NULL))
 }
 
 log_warn <- function(fmt, ...) {                            # emit WARN-level message if allowed
   if (.should_emit("WARN")) {
     .emit_line("WARN", .format_message(fmt, ...))
   }
-  invisible(NULL)
+  return(invisible(NULL))
 }
 
 log_error <- function(fmt, ...) {                           # emit ERROR-level message (always shown when allowed)
   if (.should_emit("ERROR")) {
     .emit_line("ERROR", .format_message(fmt, ...))
   }
-  invisible(NULL)
+  return(invisible(NULL))
 }
 
 log_banner <- function(text) {                              # convenience helper to emit run delimiter banner
@@ -159,6 +159,6 @@ log_banner <- function(text) {                              # convenience helper
   log_info(bar)
   log_info("%s", text)
   log_info(bar)
-  invisible(NULL)
+  return(invisible(NULL))
 }
 

--- a/main.R
+++ b/main.R
@@ -53,43 +53,43 @@ suppressPackageStartupMessages({                            # suppress package b
 .pipeline_prepare <- function(args) {
   rows_loaded <- 0L
   rows_filtered <- 0L
-  df_raw <- NULL
-  df_clean <- NULL
-  df_plus <- NULL
-  df_filtered <- NULL
+  raw <- NULL
+  cleaned <- NULL
+  derived <- NULL
+  filtered <- NULL
 
   with_log_context(list(stage = "ingest"), {
-    df_raw <<- ingest_csv(args$input)
-    rows_loaded <<- nrow(df_raw)
+    raw <<- ingest_csv(args$input)
+    rows_loaded <<- nrow(raw)
     log_info(
       "diagnostic: class(raw)=%s; nrow=%s; names[1:5]=%s",
-      paste(class(df_raw), collapse = "/"),
-      NROW(df_raw),
-      paste(utils::head(names(df_raw), 5), collapse = ",")
+      paste(class(raw), collapse = "/"),
+      NROW(raw),
+      paste(utils::head(names(raw), 5), collapse = ",")
     )
-    stopifnot(is.data.frame(df_raw), nrow(df_raw) > 0)
+    stopifnot(is.data.frame(raw), nrow(raw) > 0)
   })
 
   with_log_context(list(stage = "validate"), {
-    validate_schema(df_raw)
+    validate_schema(raw)
   })
 
   with_log_context(list(stage = "clean"), {
-    df_clean <<- clean_all(df_raw)
+    cleaned <<- clean_all(raw)
   })
 
   with_log_context(list(stage = "derive"), {
-    df_plus <<- derive_fields(df_clean)
+    derived <<- derive_fields(cleaned)
   })
 
   with_log_context(list(stage = "filter"), {
-    df_filtered <<- filter_years(df_plus, years = 2021:2023)
-    assert_year_filter(df_filtered, allowed_years = 2021:2023)
-    rows_filtered <<- nrow(df_filtered)
+    filtered <<- filter_years(derived, years = 2021:2023)
+    assert_year_filter(filtered, allowed_years = 2021:2023)
+    rows_filtered <<- nrow(filtered)
   })
 
   list(
-    data = df_filtered,
+    data = filtered,
     rows_loaded = rows_loaded,
     rows_filtered = rows_filtered
   )

--- a/tests/test_no_clobber.R
+++ b/tests/test_no_clobber.R
@@ -1,0 +1,32 @@
+source_module <- function(...) {
+  rel <- file.path(...)
+  candidates <- c(file.path("..", rel), rel)
+  for (path in candidates) {
+    if (file.exists(path)) {
+      source(path, chdir = TRUE)
+      return(invisible(TRUE))
+    }
+  }
+  stop(sprintf("Unable to locate module '%s' from test.", rel))
+}
+
+source_module("R", "utils_log.R")
+source_module("R", "ingest.R")
+source_module("R", "validate.R")
+source_module("R", "clean.R")
+
+library(testthat)
+
+test_that("logging never clobbers data frames", {
+  df <- ingest_csv("dpwh_flood_control_projects.csv")
+  expect_true(is.data.frame(df))
+  expect_gt(nrow(df), 0)
+
+  .log_info("class=%s n=%s", paste(class(df), collapse = "/"), nrow(df))
+  expect_true(is.data.frame(df))
+
+  validate_schema(df)
+  cleaned <- clean_all(df)
+  expect_true(is.data.frame(cleaned))
+  expect_gt(nrow(cleaned), 0)
+})


### PR DESCRIPTION
## Summary
- use canonical `raw`/`cleaned`/`derived`/`filtered` variables in the pipeline prep helper so logging side effects cannot drop data frames
- make all logging shims explicitly return `invisible(NULL)` and add a regression test that ensures `.log_info()` calls do not overwrite ingested data

## Testing
- ⚠️ `Rscript -e "testthat::test_dir('tests')"` *(unavailable: Rscript is not installed in the container)*
- ⚠️ `Rscript main.R --input "dpwh_flood_control_projects.csv" --outdir outputs` *(unavailable: Rscript is not installed in the container)*
- ⚠️ `printf "1\n2\n" | Rscript main.R --input "dpwh_flood_control_projects.csv" --outdir outputs --interactive` *(unavailable: Rscript is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc16cb72c83289310689dc1b21814