### PR TITLE
Align interactive preview headings with shared constants

### DIFF
--- a/R/constants.R
+++ b/R/constants.R
@@ -1,0 +1,22 @@
+# constants.R
+# ------------------------------------------------------------------------------
+# Purpose   : Central place for shared string constants used by the pipeline,
+#             especially values that must stay in sync between the interactive
+#             CLI preview and the verification suite.
+# ------------------------------------------------------------------------------
+
+REPORT_FILES <- list(
+  r1 = "report1_regional_efficiency.csv",
+  r2 = "report2_top_contractors.csv",
+  r3 = "report3_overrun_trends.csv",
+  summary = "summary.json"
+)
+
+REPORT_PREVIEW_HEADINGS <- list(
+  report1 = "Report 1: Regional Flood Mitigation Efficiency",
+  report2 = "Report 2: Top Contractors Performance Ranking",
+  report3 = "Report 3: Annual Project Type Cost Overrun Trends"
+)
+
+REPORT_PREVIEW_ORDER <- c("report1", "report2", "report3")
+

--- a/R/interactive.R
+++ b/R/interactive.R
@@ -1,0 +1,45 @@
+# interactive.R
+# ------------------------------------------------------------------------------
+# Purpose   : Provide the interactive console preview used when the CLI is run
+#             with --interactive. The helper prints each report heading followed
+#             by a small preview of the corresponding data frame.
+# ------------------------------------------------------------------------------
+
+if (!exists("REPORT_PREVIEW_HEADINGS", inherits = TRUE)) {
+  if (file.exists("constants.R")) {
+    source("constants.R", chdir = TRUE)
+  } else if (file.exists(file.path("R", "constants.R"))) {
+    source(file.path("R", "constants.R"), chdir = TRUE)
+  }
+}
+
+.run_interactive_spec <- function(reports, preview_rows = 5L) {
+  if (!is.list(reports)) {
+    stop(".run_interactive_spec(): 'reports' must be a named list of data frames.")
+  }
+  expected_keys <- REPORT_PREVIEW_ORDER
+  missing <- setdiff(expected_keys, names(reports))
+  if (length(missing) > 0L) {
+    stop(sprintf(".run_interactive_spec(): missing report(s): %s", paste(missing, collapse = ", ")))
+  }
+
+  cat("Interactive Preview\n")
+  cat("===================\n\n")
+
+  for (key in expected_keys) {
+    heading <- REPORT_PREVIEW_HEADINGS[[key]]
+    cat(heading, "\n", sep = "")
+    data <- reports[[key]]
+    if (is.data.frame(data) && nrow(data) > 0L) {
+      utils::print(utils::head(data, preview_rows))
+    } else if (is.data.frame(data)) {
+      utils::print(data)
+    } else {
+      cat("[No data available]\n")
+    }
+    cat("\n")
+  }
+
+  invisible(NULL)
+}
+

--- a/R/io.R
+++ b/R/io.R
@@ -17,6 +17,18 @@ suppressPackageStartupMessages({                             # ensure clean cons
   library(jsonlite)
 })
 
+.path_join <- function(dir, filename) {                      # simple helper to join directory and filename
+  file.path(dir, filename)
+}
+
+if (!exists("REPORT_FILES", inherits = TRUE)) {              # ensure shared constants available when sourced standalone
+  if (file.exists("constants.R")) {
+    source("constants.R", chdir = TRUE)
+  } else if (file.exists(file.path("R", "constants.R"))) {
+    source(file.path("R", "constants.R"), chdir = TRUE)
+  }
+}
+
 
 
 # ---- readr write compatibility (pre-2.0 vs >=2.0) ----------------------------
@@ -141,5 +153,21 @@ write_summary_outdir <- function(x, outdir) {
   path <- .path_join(outdir, REPORT_FILES$summary)
   write_summary_json(x, path)
   path
+}
+
+path_report1 <- function(outdir) {                             # helper for tests/verification
+  .path_join(outdir, REPORT_FILES$r1)
+}
+
+path_report2 <- function(outdir) {                             # helper for tests/verification
+  .path_join(outdir, REPORT_FILES$r2)
+}
+
+path_report3 <- function(outdir) {                             # helper for tests/verification
+  .path_join(outdir, REPORT_FILES$r3)
+}
+
+path_summary <- function(outdir) {                             # helper for tests/verification
+  .path_join(outdir, REPORT_FILES$summary)
 }
 

--- a/R/verify.R
+++ b/R/verify.R
@@ -19,6 +19,30 @@ suppressPackageStartupMessages({
   library(jsonlite)
 })
 
+if (!exists("REPORT_PREVIEW_HEADINGS", inherits = TRUE)) {
+  if (file.exists("constants.R")) {
+    source("constants.R", chdir = TRUE)
+  } else if (file.exists(file.path("R", "constants.R"))) {
+    source(file.path("R", "constants.R"), chdir = TRUE)
+  }
+}
+
+if (!exists(".run_interactive_spec", mode = "function")) {
+  if (file.exists("interactive.R")) {
+    source("interactive.R", chdir = TRUE)
+  } else if (file.exists(file.path("R", "interactive.R"))) {
+    source(file.path("R", "interactive.R"), chdir = TRUE)
+  }
+}
+
+if (!exists("path_report1", mode = "function")) {
+  if (file.exists("io.R")) {
+    source("io.R", chdir = TRUE)
+  } else if (file.exists(file.path("R", "io.R"))) {
+    source(file.path("R", "io.R"), chdir = TRUE)
+  }
+}
+
 .status_label <- function(ok) if (ok) "[PASS]" else "[FAIL]"
 
 .verify_numeric_format <- function(values) {
@@ -62,20 +86,24 @@ verify_outputs <- function(dataset, reports, summary, outdir, fmt_opts) {
 
   report_lines <- c(report_lines, "Schema & Formatting", "----------------------")
 
-
+  path1 <- path_report1(outdir)
+  path2 <- path_report2(outdir)
+  path3 <- path_report3(outdir)
+  path_summary_json <- path_summary(outdir)
 
   r1_file <- .read_csv_as_character(path1)
   r2_file <- .read_csv_as_character(path2)
   r3_file <- .read_csv_as_character(path3)
 
-
+  expected_r1 <- c("Region", "MainIsland", "TotalBudget", "MedianSavings", "AvgDelay", "HighDelayPct", "EfficiencyScore")
+  expected_r2 <- c("Contractor", "NumProjects", "TotalCost", "AvgDelay", "TotalSavings", "ReliabilityIndex", "RiskFlag")
   expected_r3 <- c("FundingYear", "TypeOfWork", "TotalProjects", "AvgSavings", "OverrunRate", "YoYChange")
 
   append_check(identical(names(r1_file), expected_r1), "Report 1 header matches expected schema.")
   append_check(identical(names(r2_file), expected_r2), "Report 2 header matches expected schema.")
   append_check(identical(names(r3_file), expected_r3), "Report 3 header matches expected schema.")
 
-
+  efficiency_ok <- all(is.na(reports$report1$EfficiencyScore) | (reports$report1$EfficiencyScore >= 0 & reports$report1$EfficiencyScore <= 100))
   reliability_ok <- all(is.na(reports$report2$ReliabilityIndex) | (reports$report2$ReliabilityIndex >= 0 & reports$report2$ReliabilityIndex <= 100))
   overrun_ok <- all(is.na(reports$report3$OverrunRate) | (reports$report3$OverrunRate >= 0 & reports$report3$OverrunRate <= 100))
 
@@ -123,7 +151,15 @@ verify_outputs <- function(dataset, reports, summary, outdir, fmt_opts) {
 
   report_lines <- c(report_lines, "", "UX & Documentation", "----------------------")
 
-  preview_titles <- c(
+  preview_titles <- unname(unlist(REPORT_PREVIEW_HEADINGS))
+  if (exists(".run_interactive_spec", mode = "function")) {
+    preview_capture <- capture.output(.run_interactive_spec(reports, preview_rows = 3L))
+    preview_heading_lines <- preview_capture[grepl("^Report [0-9]+:", preview_capture)]
+    preview_subset <- preview_heading_lines[seq_len(min(length(preview_heading_lines), length(preview_titles)))]
+    preview_ok <- identical(preview_subset, preview_titles)
+  } else {
+    preview_ok <- FALSE
+  }
 
   append_check(preview_ok, "Interactive preview headings mirror sample output titles.")
 

--- a/main.R
+++ b/main.R
@@ -30,10 +30,12 @@ suppressPackageStartupMessages({                            # suppress package b
 }
 
 # Source logging & utilities first (used by all stages) -------------------------
+.source_or_die("R/constants.R")                              # shared filenames/headings used across modules
 .source_or_die("R/utils_log.R")                              # log_* API (INFO/WARN/ERROR + context helpers)
 .source_or_die("R/utils_cli.R")                              # build_cli(), validate_cli_args(), normalize_cli_paths()
 .source_or_die("R/utils_format.R")                           # safe_mean/median, minmax_0_100, format_dataframe()
 .source_or_die("R/io.R")                                     # ensure_outdir(), write_report_csv(), write_summary_json()
+.source_or_die("R/interactive.R")                            # .run_interactive_spec() preview helper
 
 # Source pipeline stage modules -------------------------------------------------
 .source_or_die("R/ingest.R")                                 # ingest_csv()


### PR DESCRIPTION
## Summary
- add a constants module for report filenames and preview headings
- wire the interactive preview helper to use the shared headings and source it from the CLI entrypoint
- update IO/verification helpers to rely on the shared constants and validate preview output titles

## Testing
- `Rscript /tmp/run_verify.R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dd36c7103c8328ba4a2520e207b58c