### PR TITLE
Allow coordinate synonyms in schema validation

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -71,7 +71,7 @@ validate_schema <- function(df) {
     "FundingYear", "TypeOfWork",
     "StartDate", "ActualCompletionDate",
     "ApprovedBudgetForContract", "ContractCost",
-    "Contractor", "Latitude", "Longitude"
+    "Contractor"
   )
   missing_required <- setdiff(required_cols, nms)
   if (length(missing_required) > 0L) {
@@ -80,6 +80,15 @@ validate_schema <- function(df) {
         "validate_schema(): missing required columns: %s.",
         paste(missing_required, collapse = ", ")
       ),
+      call. = FALSE
+    )
+  }
+
+  has_canonical_coords <- all(c("Latitude", "Longitude") %in% nms)
+  has_synonym_coords <- all(c("ProjectLatitude", "ProjectLongitude") %in% nms)
+  if (!has_canonical_coords && !has_synonym_coords) {
+    stop(
+      "validate_schema(): missing required columns: Latitude, Longitude.",
       call. = FALSE
     )
   }


### PR DESCRIPTION
## Summary
- relax the required column list to exclude Latitude/Longitude from the generic check
- accept either Latitude/Longitude or ProjectLatitude/ProjectLongitude as the coordinate pair in validate_schema

## Testing
- Rscript -e "source('R/ingest.R'); source('R/validate.R'); d<-ingest_csv('dpwh_flood_control_projects.csv'); validate_schema(d)" *(fails: Rscript not available in container)*
- Rscript -e "testthat::test_file('tests/test_validate.R')" *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dde2ae6a648328b3a697cb55de18f8