### PR TITLE
Clarify coordinate validation error message

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -88,7 +88,7 @@ validate_schema <- function(df) {
   has_synonym_coords <- all(c("ProjectLatitude", "ProjectLongitude") %in% nms)
   if (!has_canonical_coords && !has_synonym_coords) {
     stop(
-      "validate_schema(): missing required columns: Latitude, Longitude.",
+      "validate_schema(): missing coordinates (Latitude/Longitude or ProjectLatitude/ProjectLongitude).",
       call. = FALSE
     )
   }


### PR DESCRIPTION
## Summary
- clarify the validate_schema() error message when no coordinate columns are present

## Testing
- Rscript tests/test_validate.R *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68dde65ad41c83288526f911dbf277ac