### PR TITLE
Ensure validate schema logs through project logger

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -49,8 +49,6 @@ validate_schema <- function(df) {
 
   if (exists("log_info", mode = "function")) {
     log_info("validate_schema(): rows=%d", row_count)
-  } else {
-    message(sprintf("validate_schema(): rows=%d", row_count))
   }
 
   # No duplicated headers -----------------------------------------------------

--- a/tests/test_validate.R
+++ b/tests/test_validate.R
@@ -10,6 +10,7 @@ source_module <- function(...) {
   stop(sprintf("Unable to locate module '%s' from test.", rel))
 }
 
+source_module("R", "utils_log.R")
 source_module("R", "ingest.R")
 source_module("R", "validate.R")
 


### PR DESCRIPTION
## Summary
- load the logging utilities in the validation test harness so helper functions are available
- ensure `validate_schema()` emits through `log_info()` when the logger is present instead of falling back to `message()`

## Testing
- `Rscript -e 'testthat::test_dir("tests")'` *(fails: `Rscript` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dde65251548328a9886cf8d45a33e0