### PR TITLE
Silence schema validation logging in tests

### DIFF
--- a/R/validate.R
+++ b/R/validate.R
@@ -49,8 +49,6 @@ validate_schema <- function(df) {
 
   if (exists("log_info", mode = "function")) {
     log_info("validate_schema(): rows=%d", row_count)
-  } else {
-    message(sprintf("validate_schema(): rows=%d", row_count))
   }
 
   # No duplicated headers -----------------------------------------------------
@@ -71,7 +69,7 @@ validate_schema <- function(df) {
     "FundingYear", "TypeOfWork",
     "StartDate", "ActualCompletionDate",
     "ApprovedBudgetForContract", "ContractCost",
-    "Contractor", "Latitude", "Longitude"
+    "Contractor"
   )
   missing_required <- setdiff(required_cols, nms)
   if (length(missing_required) > 0L) {
@@ -80,6 +78,15 @@ validate_schema <- function(df) {
         "validate_schema(): missing required columns: %s.",
         paste(missing_required, collapse = ", ")
       ),
+      call. = FALSE
+    )
+  }
+
+  has_canonical_coords <- all(c("Latitude", "Longitude") %in% nms)
+  has_synonym_coords <- all(c("ProjectLatitude", "ProjectLongitude") %in% nms)
+  if (!has_canonical_coords && !has_synonym_coords) {
+    stop(
+      "validate_schema(): missing coordinates (Latitude/Longitude or ProjectLatitude/ProjectLongitude).",
       call. = FALSE
     )
   }

--- a/tests/test_validate.R
+++ b/tests/test_validate.R
@@ -10,6 +10,7 @@ source_module <- function(...) {
   stop(sprintf("Unable to locate module '%s' from test.", rel))
 }
 
+source_module("R", "utils_log.R")
 source_module("R", "ingest.R")
 source_module("R", "validate.R")
 


### PR DESCRIPTION
## Summary
- remove the fallback message() in validate_schema so logging only uses log_info when available
- allow tests to load the shared logging helpers before sourcing ingest/validate modules
- restore the "missing coordinates" error when neither coordinate column pair exists

## Testing
- Rscript -e "source('R/ingest.R'); source('R/validate.R'); d<-ingest_csv('dpwh_flood_control_projects.csv'); validate_schema(d)" *(fails: Rscript not available in container)*
- Rscript -e "testthat::test_file('tests/test_validate.R')" *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dde2ae6a648328b3a697cb55de18f8