### PR TITLE
Refine report1 aggregations

### DIFF
--- a/R/report1.R
+++ b/R/report1.R
@@ -1,40 +1,50 @@
 # report1.R
 # ------------------------------------------------------------------------------
 # Purpose   : Produce the Regional Flood Mitigation Efficiency report.
-# Contract  : report_regional_efficiency(df) -> tibble with columns
-#   Region, MainIsland, TotalApprovedBudget, MedianSavings, AvgDelay,
-#   Delay30Rate, EfficiencyScore (sorted by EfficiencyScore desc).
+# Contract  : build_report1(df) -> tibble with columns
+#   Region, MainIsland, TotalBudget, MedianSavings, AvgDelay,
+#   HighDelayPct, EfficiencyScore (sorted by EfficiencyScore desc).
 # Rubric    : Correctness (aggregations & min-max normalisation), Performance
 #             (dplyr group summarise), Readability (formal comments), UX (stable
-#             schema ordering).
+#             schema ordering and formatted values).
 # ------------------------------------------------------------------------------
+
+if (!exists("minmax_0_100", mode = "function")) {          # ensure shared helpers available
+  source("R/utils_format.R")
+}
 
 suppressPackageStartupMessages({                             # quiet load for CLI/tests
   library(dplyr)
 })
 
-report_regional_efficiency <- function(df) {                 # build report 1 summary
-  if (!is.data.frame(df)) stop("report_regional_efficiency(): 'df' must be a data frame.")
-  reg_summ <- df %>%
+build_report1 <- function(df) {                               # build report 1 summary
+  if (!is.data.frame(df)) stop("build_report1(): 'df' must be a data frame.")
+
+  summary_tbl <- df %>%
     group_by(Region, MainIsland) %>%
     summarise(
-      TotalApprovedBudget = safe_sum(ApprovedBudgetForContract),
+      TotalBudget = safe_sum(ApprovedBudgetForContract),
       MedianSavings = safe_median(CostSavings),
       AvgDelay = safe_mean(CompletionDelayDays),
-      Delay30Rate = 100 * safe_mean(CompletionDelayDays > 30),
-      EfficiencyRaw = {
-        adj_delay <- dplyr::case_when(
-          is.na(AvgDelay) ~ NA_real_,
-          abs(AvgDelay) < 1e-6 ~ dplyr::if_else(AvgDelay < 0, -1e-6, 1e-6),
-          TRUE ~ AvgDelay
-        )
-        ifelse(!is.na(MedianSavings) & !is.na(adj_delay), (MedianSavings / adj_delay) * 100, NA_real_)
-      },
+      HighDelayPct = safe_mean(CompletionDelayDays > 30) * 100,
       .groups = "drop"
     ) %>%
+    ungroup()
+
+  report <- summary_tbl %>%
     mutate(
-      EfficiencyScore = minmax_0_100(EfficiencyRaw)
+      EfficiencyScore = {
+        delay_denom <- ifelse(is.na(AvgDelay), NA_real_, pmax(AvgDelay, 1))
+        raw_score <- (MedianSavings / delay_denom) * 100
+        minmax_0_100(raw_score)
+      }
     ) %>%
-    select(Region, MainIsland, TotalApprovedBudget, MedianSavings, AvgDelay, Delay30Rate, EfficiencyScore) %>%
-    arrange(desc(EfficiencyScore), Region, MainIsland)
+    select(Region, MainIsland, TotalBudget, MedianSavings, AvgDelay, HighDelayPct, EfficiencyScore) %>%
+    arrange(desc(EfficiencyScore))
+
+  format_dataframe(report)
+}
+
+report_regional_efficiency <- function(df) {                  # backwards compatibility helper
+  build_report1(df)
 }


### PR DESCRIPTION
## Summary
- reuse the shared safe_* helpers when summarising report 1 metrics and explicitly drop grouping metadata
- compute the efficiency score from the summarised values before ordering the columns for formatting

## Testing
- Not Run (Rscript unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dde3a826d8832882ae1884282b561b