### PR TITLE
Load dependencies for report1 helper

### DIFF
--- a/R/report1.R
+++ b/R/report1.R
@@ -9,6 +9,40 @@
 #             schema ordering and formatted values).
 # ------------------------------------------------------------------------------
 
+suppressPackageStartupMessages({                             # quiet load for tidy verbs
+  library(dplyr)
+})
 
-  build_report1(df)
+if (!exists("safe_sum", mode = "function")) {               # ensure shared helpers available
+  source("R/utils_format.R")
+}
+
+build_report1 <- function(df) {
+  stopifnot(is.data.frame(df))
+
+  summary_tbl <- df %>%
+    dplyr::group_by(Region, MainIsland) %>%
+    dplyr::summarise(
+      TotalBudget = safe_sum(ApprovedBudgetForContract),
+      MedianSavings = safe_median(CostSavings),
+      AvgDelay = safe_mean(CompletionDelayDays),
+      HighDelayPct = safe_mean(CompletionDelayDays > 30) * 100,
+      .groups = "drop"
+    )
+
+  efficiency <- (summary_tbl$MedianSavings / pmax(summary_tbl$AvgDelay, 1)) * 100
+  summary_tbl$EfficiencyScore <- minmax_0_100(efficiency)
+
+  summary_tbl %>%
+    dplyr::arrange(dplyr::desc(EfficiencyScore)) %>%
+    dplyr::select(
+      Region,
+      MainIsland,
+      TotalBudget,
+      MedianSavings,
+      AvgDelay,
+      HighDelayPct,
+      EfficiencyScore
+    ) %>%
+    format_dataframe()
 }


### PR DESCRIPTION
## Summary
- add the build_report1 implementation to compute regional flood mitigation metrics
- aggregate project data per region and derive efficiency scores using shared helpers
- format the resulting report table with consistent numeric presentation
- ensure report1 loads dplyr and shared formatting utilities when sourced directly

## Testing
- Rscript -e "source('R/report1.R'); d<-data.frame(Region='NCR',MainIsland='Luzon',ApprovedBudgetForContract=c(10,20),CostSavings=c(2,3),CompletionDelayDays=c(10,20)); r<-build_report1(d); stopifnot(identical(names(r),c('Region','MainIsland','TotalBudget','MedianSavings','AvgDelay','HighDelayPct','EfficiencyScore'))); cat('R1 OK\n')" *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de052ad7e083289295d44e4ef3163b