### PR TITLE
Ensure report1 sources formatting utilities explicitly

### DIFF
--- a/R/report1.R
+++ b/R/report1.R
@@ -9,11 +9,24 @@
 #             schema ordering and formatted values).
 # ------------------------------------------------------------------------------
 
+.load_utils_format <- function() {
+  caller <- sys.frame(1)
+  ofile <- caller$ofile
+  if (is.null(ofile)) {
+    stop(".load_utils_format(): unable to determine the calling file location.")
+  }
+  utils_path <- file.path(normalizePath(dirname(ofile)), "utils_format.R")
+  if (!file.exists(utils_path)) {
+    stop(sprintf(".load_utils_format(): expected helper file at '%s' but it was not found.", utils_path))
+  }
+  sys.source(utils_path, envir = parent.frame())
+}
+
+.load_utils_format()
+
 suppressPackageStartupMessages({                             # quiet load for tidy verbs
   library(dplyr)
 })
-
-
 
 build_report1 <- function(df) {
   stopifnot(is.data.frame(df))


### PR DESCRIPTION
## Summary
- add a simplified `.load_utils_format()` helper that sources `utils_format.R` via an absolute path
- invoke the loader before defining `build_report1()` so formatting helpers are always available

## Testing
- `Rscript -e "source('R/report1.R'); d<-data.frame(Region=c('A','A','B'), MainIsland=c('Luzon','Luzon','Visayas'), ApprovedBudgetForContract=c(100,200,150), CostSavings=c(10,NA,20), CompletionDelayDays=c(5,45,NA)); r<-build_report1(d); print(r)"` *(fails: `Rscript` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de1e56bdb88328a3ea5fff7a11ada5