### PR TITLE
Restore contractor ranking entrypoint and ranking schema

### DIFF
--- a/R/report2.R
+++ b/R/report2.R
@@ -1,39 +1,59 @@
 # report2.R
 # ------------------------------------------------------------------------------
 # Purpose   : Produce the Top Contractors Performance Ranking report.
-# Contract  : report_contractor_ranking(df) -> tibble with columns
-#   Contractor, NumProjects, TotalCost, AvgDelay, TotalSavings,
-#   ReliabilityIndex, RiskFlag. Keeps contractors with ≥5 projects, top 15 by
-#   TotalCost (descending).
+# Contract  : build_report2(df) -> tibble with columns Rank, Contractor,
+#   TotalCost, NumProjects, AvgDelay, TotalSavings, ReliabilityIndex, RiskFlag.
 # ------------------------------------------------------------------------------
 
 suppressPackageStartupMessages({                             # quiet load
   library(dplyr)
 })
 
-report_contractor_ranking <- function(df) {                  # build contractor leaderboard
-  if (!is.data.frame(df)) stop("report_contractor_ranking(): 'df' must be a data frame.")
-  df %>%
-    group_by(Contractor) %>%
-    summarise(
-      TotalCost = safe_sum(ContractCost),
+build_report2 <- function(df) {                              # build contractor leaderboard
+  if (!is.data.frame(df)) stop("build_report2(): 'df' must be a data frame.")
+
+  summary_tbl <- df %>%
+    dplyr::group_by(Contractor) %>%
+    dplyr::summarise(
+      TotalCost = sum(ContractCost, na.rm = TRUE),
       NumProjects = dplyr::n(),
-      AvgDelay = safe_mean(CompletionDelayDays),
-      TotalSavings = safe_sum(CostSavings),
+      AvgDelay = mean(CompletionDelayDays, na.rm = TRUE),
+      TotalSavings = sum(CostSavings, na.rm = TRUE),
       .groups = "drop"
     ) %>%
-    filter(NumProjects >= 5) %>%
-    arrange(desc(TotalCost), Contractor) %>%
-    slice_head(n = 15) %>%
-    mutate(
+    dplyr::mutate(
+      AvgDelay = ifelse(is.nan(AvgDelay), NA_real_, AvgDelay)
+    ) %>%
+    dplyr::filter(NumProjects >= 5)
+
+  ranked <- summary_tbl %>%
+    dplyr::arrange(dplyr::desc(TotalCost), Contractor) %>%
+    dplyr::slice_head(n = 15) %>%
+    dplyr::mutate(
       ReliabilityIndex = {
-        ri <- (1 - (AvgDelay / 90)) * (TotalSavings / TotalCost) * 100
-        bad <- !is.finite(ri) | is.na(TotalCost) | TotalCost <= 0
-        ri[bad] <- NA_real_
+        ri <- (1 - (AvgDelay / 90)) * (TotalSavings / pmax(TotalCost, 1)) * 100
+        ri[is.nan(ri) | is.infinite(ri)] <- NA_real_
+        ri <- pmax(ri, 0)
         ri <- pmin(ri, 100)
         ri
       },
-      RiskFlag = dplyr::if_else(is.na(ReliabilityIndex) | ReliabilityIndex < 50, "High Risk", "Low Risk")
-    ) %>%
-    select(Contractor, NumProjects, TotalCost, AvgDelay, TotalSavings, ReliabilityIndex, RiskFlag)
+      RiskFlag = ifelse(is.na(ReliabilityIndex) | ReliabilityIndex < 50, "High Risk", "Low Risk"),
+      Rank = dplyr::row_number()
+    )
+
+  ranked %>%
+    dplyr::select(
+      Rank,
+      Contractor,
+      TotalCost,
+      NumProjects,
+      AvgDelay,
+      TotalSavings,
+      ReliabilityIndex,
+      RiskFlag
+    )
+}
+
+report_contractor_ranking <- function(df) {                  # backwards-compatible entry point
+  build_report2(df)
 }


### PR DESCRIPTION
## Summary
- rebuild report 2 aggregation with explicit ranking, reliability clamp, and rank column selection
- reintroduce the `report_contractor_ranking()` wrapper so existing callers receive the updated schema

## Testing
- `Rscript -e "testthat::test_file('tests/test_report2.R')"` *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68de215f54fc8328b4c968ff4b14ae53