### PR TITLE
Refine contractor ranking report calculations

### DIFF
--- a/R/report2.R
+++ b/R/report2.R
@@ -1,39 +1,58 @@
 # report2.R
 # ------------------------------------------------------------------------------
 # Purpose   : Produce the Top Contractors Performance Ranking report.
-# Contract  : report_contractor_ranking(df) -> tibble with columns
-#   Contractor, NumProjects, TotalCost, AvgDelay, TotalSavings,
-#   ReliabilityIndex, RiskFlag. Keeps contractors with ≥5 projects, top 15 by
-#   TotalCost (descending).
+# Contract  : build_report2(df) -> tibble with columns Rank, Contractor,
+#   TotalCost, NumProjects, AvgDelay, TotalSavings, ReliabilityIndex, RiskFlag.
 # ------------------------------------------------------------------------------
 
-suppressPackageStartupMessages({                             # quiet load
+suppressPackageStartupMessages({                             # align with other report helpers
   library(dplyr)
 })
 
-report_contractor_ranking <- function(df) {                  # build contractor leaderboard
-  if (!is.data.frame(df)) stop("report_contractor_ranking(): 'df' must be a data frame.")
+build_report2 <- function(df) {                              # build contractor leaderboard
+  if (!is.data.frame(df)) stop("build_report2(): 'df' must be a data frame.")
+
   df %>%
-    group_by(Contractor) %>%
-    summarise(
-      TotalCost = safe_sum(ContractCost),
+    dplyr::group_by(Contractor) %>%
+    dplyr::summarise(
+      TotalCost = sum(ContractCost, na.rm = TRUE),
       NumProjects = dplyr::n(),
-      AvgDelay = safe_mean(CompletionDelayDays),
-      TotalSavings = safe_sum(CostSavings),
+      AvgDelay = mean(CompletionDelayDays, na.rm = TRUE),
+      TotalSavings = sum(CostSavings, na.rm = TRUE),
       .groups = "drop"
     ) %>%
-    filter(NumProjects >= 5) %>%
-    arrange(desc(TotalCost), Contractor) %>%
-    slice_head(n = 15) %>%
-    mutate(
-      ReliabilityIndex = {
-        ri <- (1 - (AvgDelay / 90)) * (TotalSavings / TotalCost) * 100
-        bad <- !is.finite(ri) | is.na(TotalCost) | TotalCost <= 0
-        ri[bad] <- NA_real_
-        ri <- pmin(ri, 100)
-        ri
-      },
-      RiskFlag = dplyr::if_else(is.na(ReliabilityIndex) | ReliabilityIndex < 50, "High Risk", "Low Risk")
+    dplyr::mutate(
+      AvgDelay = dplyr::na_if(AvgDelay, NaN),
+      ReliabilityIndex = (1 - (AvgDelay / 90)) * (TotalSavings / pmax(TotalCost, 1)) * 100,
+      ReliabilityIndex = pmax(pmin(ReliabilityIndex, 100), 0),
+      ReliabilityIndex = dplyr::if_else(
+        is.finite(ReliabilityIndex),
+        ReliabilityIndex,
+        NA_real_
+      ),
+      RiskFlag = dplyr::if_else(
+        ReliabilityIndex < 50,
+        "High Risk",
+        "Low Risk",
+        missing = NA_character_
+      )
     ) %>%
-    select(Contractor, NumProjects, TotalCost, AvgDelay, TotalSavings, ReliabilityIndex, RiskFlag)
+    dplyr::filter(NumProjects >= 5) %>%
+    dplyr::arrange(dplyr::desc(TotalCost), Contractor) %>%
+    dplyr::slice_head(n = 15) %>%
+    dplyr::mutate(Rank = dplyr::row_number()) %>%
+    dplyr::select(
+      Rank,
+      Contractor,
+      TotalCost,
+      NumProjects,
+      AvgDelay,
+      TotalSavings,
+      ReliabilityIndex,
+      RiskFlag
+    )
+}
+
+report_contractor_ranking <- function(df) {                  # backwards-compatible entry point
+  build_report2(df)
 }


### PR DESCRIPTION
## Summary
- load dplyr once and rebuild build_report2() with tidy summarise/mutate steps to compute contractor totals, clamp reliability, and assign rankings in the required column order
- keep report_contractor_ranking() delegating to the helper for backward compatibility

## Testing
- `Rscript -e "testthat::test_file('tests/test_report2.R')"` *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68de215f54fc8328b4c968ff4b14ae53