### PR TITLE
Update report2 test to expect all columns

### DIFF
--- a/tests/test_report2.R
+++ b/tests/test_report2.R
@@ -42,7 +42,10 @@ test_that("report 2 enforces eligibility and ranking rules", {
   expect_equal(
     colnames(report),
     c(
-
+      "Rank",
+      "Contractor",
+      "TotalCost",
+      "NumProjects",
       "AvgDelay",
       "TotalSavings",
       "ReliabilityIndex",


### PR DESCRIPTION
## Summary
- align the report 2 test with the full REQ-0007 column list

## Testing
- `Rscript -e "testthat::test_file('tests/test_report2.R')"` *(fails: Rscript not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de38cf080083288de58e3d0ecf1944