### PR TITLE
Implement summary aggregation and JSON writer

### DIFF
--- a/R/summary.R
+++ b/R/summary.R
@@ -17,40 +17,13 @@ suppressPackageStartupMessages({                             # quiet load
 
 build_summary <- function(df) {                              # assemble scalar metrics for JSON
   if (!is.data.frame(df)) stop("build_summary(): 'df' must be a data frame.")
-  delays <- as.numeric(df$CompletionDelayDays)
-  if (length(delays) == 0L || all(is.na(delays))) {
-    global_avg_delay <- NA_real_
-  } else {
-    global_avg_delay <- round(mean(delays, na.rm = TRUE), 2)
-  }
 
-  savings_vec <- as.numeric(df$CostSavings)
-  if (length(savings_vec) == 0L || all(is.na(savings_vec))) {
-    total_savings <- NA_real_
-  } else {
-    total_savings <- round(sum(savings_vec, na.rm = TRUE), 2)
-    if (!is.finite(total_savings)) {
-      if (exists("log_warn", mode = "function")) {
-        log_warn("Summary: total_savings non-finite -> null (value=%g).", total_savings)
-      } else {
-        message(sprintf("[WARN] Summary: total_savings non-finite -> null (value=%g).", total_savings))
-      }
-      total_savings <- NA_real_
-    } else if (abs(total_savings) > 1e13) {
-      if (exists("log_warn", mode = "function")) {
-        log_warn("Summary: total_savings=%g exceeds guard threshold; writing null.", total_savings)
-      } else {
-        message(sprintf("[WARN] Summary: total_savings=%g exceeds guard threshold; writing null.", total_savings))
-      }
-      total_savings <- NA_real_
-    }
-  }
   list(
     total_projects = nrow(df),
-    total_contractors = dplyr::n_distinct(df$Contractor, na.rm = TRUE),
-    total_provinces = dplyr::n_distinct(df$Province, na.rm = TRUE),
-    global_avg_delay = global_avg_delay,
-    total_savings = total_savings
+    total_contractors = dplyr::n_distinct(df$Contractor),
+    total_provinces = dplyr::n_distinct(df$Province),
+    global_avg_delay = mean(df$CompletionDelayDays, na.rm = TRUE),
+    total_savings = sum(df$CostSavings, na.rm = TRUE)
   )
 }
 


### PR DESCRIPTION
## Summary
- simplify the summary aggregation to emit the required scalar metrics from the filtered dataset
- update the summary JSON writer to target summary.json within the requested output directory with pretty JSON formatting

## Testing
- `Rscript -e 'testthat::test_dir("tests")'` *(fails: command not found: Rscript)*

------
https://chatgpt.com/codex/tasks/task_e_68de3dc8b5548328838078fd11f80c6f