### PR TITLE
Handle implausible cost savings totals in summary

### DIFF
--- a/R/summary.R
+++ b/R/summary.R
@@ -18,12 +18,21 @@ suppressPackageStartupMessages({                             # quiet load
 build_summary <- function(df) {                              # assemble scalar metrics for JSON
   if (!is.data.frame(df)) stop("build_summary(): 'df' must be a data frame.")
 
+  total_savings <- sum(df$CostSavings, na.rm = TRUE)
+
+  if (!is.finite(total_savings) || abs(total_savings) > 1e13) {
+    if (exists("log_warn", mode = "function")) {
+      log_warn("CostSavings sum implausible (%s) -> NA.", format(total_savings, scientific = TRUE))
+    }
+    total_savings <- NA_real_
+  }
+
   list(
     total_projects = nrow(df),
     total_contractors = dplyr::n_distinct(df$Contractor),
     total_provinces = dplyr::n_distinct(df$Province),
     global_avg_delay = mean(df$CompletionDelayDays, na.rm = TRUE),
-    total_savings = sum(df$CostSavings, na.rm = TRUE)
+    total_savings = total_savings
   )
 }
 


### PR DESCRIPTION
## Summary
- guard the total_savings aggregation in build_summary() against implausible or non-finite sums
- emit a warning (when logging is available) and return NA_real_ for unrealistic totals while leaving other fields unchanged

## Testing
- Rscript tests/test_summary.R *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de44c5c3d88328bef84a8049c4bebb