### PR TITLE
Restore summary NA handling and add regression test

### DIFF
--- a/R/summary.R
+++ b/R/summary.R
@@ -33,8 +33,8 @@ build_summary <- function(df) {                              # assemble scalar m
 
   list(
     total_projects = nrow(df),
-    total_contractors = dplyr::n_distinct(df$Contractor),
-    total_provinces = dplyr::n_distinct(df$Province),
+    total_contractors = dplyr::n_distinct(df$Contractor, na.rm = TRUE),
+    total_provinces = dplyr::n_distinct(df$Province, na.rm = TRUE),
     global_avg_delay = mean(df$CompletionDelayDays, na.rm = TRUE),
     total_savings = total_savings
   )

--- a/tests/test_summary.R
+++ b/tests/test_summary.R
@@ -52,6 +52,16 @@ test_that("summary aggregates scalar metrics", {
   expect_equal(payload$total_provinces, 2)
   expect_equal(payload$global_avg_delay, 15)
   expect_equal(payload$total_savings, 250)
+
+  df_with_na <- tibble(
+    Contractor = c("A", "B", NA_character_),
+    Province = c("P1", "P2", NA_character_),
+    CompletionDelayDays = c(10, 20, 30),
+    CostSavings = c(100, 200, 300)
+  )
+  payload_with_na <- build_summary(df_with_na)
+  expect_equal(payload_with_na$total_contractors, 2)
+  expect_equal(payload_with_na$total_provinces, 2)
 })
 
 test_that("summary total_savings is finite or NA but never absurd", {


### PR DESCRIPTION
## Summary
- ensure contractor and province counts ignore missing values in the summary
- extend the summary unit test to confirm NA inputs do not inflate the counts

## Testing
- Rscript -e 'testthat::test_file("tests/test_summary.R")' *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de4ac651ec8328a33759c709fca34a