### PR TITLE
Restore IO path helpers and summary delegation

### DIFF
--- a/R/io.R
+++ b/R/io.R
@@ -56,7 +56,15 @@ path_report3 <- function(outdir) {
 }
 
 path_summary <- function(outdir) {
-  .path_join(outdir, REPORT_FILES$summary)
+  if (missing(outdir) || !is.character(outdir) || length(outdir) != 1L || is.na(outdir)) {
+    stop("path_summary(): 'outdir' must be a non-NA character scalar.")
+  }
+  looks_like_file <- grepl("\\.json$", outdir, ignore.case = TRUE)
+  if (looks_like_file) {
+    outdir
+  } else {
+    .path_join(outdir, REPORT_FILES$summary)
+  }
 }
 
 
@@ -189,6 +197,7 @@ write_report3 <- function(df, outdir, fmt_opts = list()) {
 }
 
 write_summary_outdir <- function(x, outdir) {
-  write_summary_json(x, outdir)
+  path <- path_summary(outdir)
+  write_summary_json(x, path)
 }
 


### PR DESCRIPTION
## Summary
- reintroduce the lightweight path helper utilities so report paths share one definition
- tighten path_summary() to accept either directories or explicit JSON files
- delegate write_summary_outdir() through path_summary() to keep filename logic centralized

## Testing
- Rscript -e "source('tests/test_summary.R')" *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de4ac56ec48328bb5e5b59689a06a1