### PR TITLE
Restore path helper utilities for report outputs

### DIFF
--- a/R/io.R
+++ b/R/io.R
@@ -53,11 +53,16 @@ path_report3 <- function(outdir) {
   .path_join(outdir, REPORT_FILES$report3)
 }
 
+path_summary_json <- function(outdir) {
+  .path_join(outdir, REPORT_FILES$summary)
+}
+
 path_summary <- function(outdir) {
-  if (missing(outdir) || !is.character(outdir) || length(outdir) != 1L || is.na(outdir)) {
+  path <- path_summary_json(outdir)
+  if (!length(path)) {
     stop("path_summary(): 'outdir' must be a non-NA character scalar.")
   }
-  file.path(outdir, REPORT_FILES$summary)
+  path
 }
 
 io_exports <- list(                                             # make helpers visible when sourced locally
@@ -66,6 +71,7 @@ io_exports <- list(                                             # make helpers v
   path_report1 = path_report1,
   path_report2 = path_report2,
   path_report3 = path_report3,
+  path_summary_json = path_summary_json,
   path_summary = path_summary
 )
 
@@ -196,7 +202,8 @@ write_report3 <- function(df, outdir, fmt_opts = list()) {
 }
 
 write_summary_outdir <- function(x, outdir) {
-  path <- path_summary(outdir)
+  path <- path_summary_json(outdir)
   write_summary_json(x, path)
+  path
 }
 


### PR DESCRIPTION
## Summary
- reintroduce the output path helper layer, including the summary JSON helper, and expose the mappings for tests
- have the summary writer go through the new helper so all report writers return consistent file paths

## Testing
- Rscript -e 'testthat::test_file("tests/test_filenames_and_headers.R")' *(fails: `Rscript` command not found in container)*
- R -q -e 'testthat::test_file("tests/test_summary.R")' *(fails: `R` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de535c5a348328a6c54621acc9320d