### PR TITLE
Rename report1 columns and remove inline formatting

### DIFF
--- a/R/report1.R
+++ b/R/report1.R
@@ -53,10 +53,10 @@ build_report1 <- function(df) {
   summary_tbl <- df %>%
     dplyr::group_by(Region, MainIsland) %>%
     dplyr::summarise(
-      TotalBudget = safe_sum(ApprovedBudgetForContract),
+      TotalApprovedBudget = safe_sum(ApprovedBudgetForContract),
       MedianSavings = safe_median(CostSavings),
       AvgDelay = safe_mean(CompletionDelayDays),
-      HighDelayPct = safe_mean(CompletionDelayDays > 30) * 100,
+      Delay30Rate = safe_mean(CompletionDelayDays > 30) * 100,
       .groups = "drop"
     )
 
@@ -68,11 +68,10 @@ build_report1 <- function(df) {
     dplyr::select(
       Region,
       MainIsland,
-      TotalBudget,
+      TotalApprovedBudget,
       MedianSavings,
       AvgDelay,
-      HighDelayPct,
+      Delay30Rate,
       EfficiencyScore
-    ) %>%
-    format_dataframe()
+    )
 }


### PR DESCRIPTION
## Summary
- rename the aggregated budget and delay columns in report1 to match the documented schema
- return raw numeric values from build_report1 by removing the inline dataframe formatting step

## Testing
- Rscript tests/test_report1.R *(fails: Rscript not available in container)*
- Rscript tests/test_filenames_and_headers.R *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de5bc7aa5c83288ace211a8dd399d0