### PR TITLE
Add wrapper for regional efficiency report function

### DIFF
--- a/R/report1.R
+++ b/R/report1.R
@@ -76,3 +76,7 @@ build_report1 <- function(df) {
     ) %>%
     format_dataframe()
 }
+
+report_regional_efficiency <- function(df) {
+  build_report1(df)
+}


### PR DESCRIPTION
## Summary
- add the `report_regional_efficiency` wrapper around `build_report1` so the expected name is exported

## Testing
- not run (Rscript is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68de5bbc40cc8328831d21fb4e10a5e6