### PR TITLE
Update report1 contract documentation for renamed metrics

### DIFF
--- a/R/report1.R
+++ b/R/report1.R
@@ -2,8 +2,8 @@
 # ------------------------------------------------------------------------------
 # Purpose   : Produce the Regional Flood Mitigation Efficiency report.
 # Contract  : build_report1(df) -> tibble with columns
-#   Region, MainIsland, TotalBudget, MedianSavings, AvgDelay,
-#   HighDelayPct, EfficiencyScore (sorted by EfficiencyScore desc).
+#   Region, MainIsland, TotalApprovedBudget, MedianSavings, AvgDelay,
+#   Delay30Rate, EfficiencyScore (sorted by EfficiencyScore desc).
 # Rubric    : Correctness (aggregations & min-max normalisation), Performance
 #             (dplyr group summarise), Readability (formal comments), UX (stable
 #             schema ordering and formatted values).


### PR DESCRIPTION
## Summary
- update the report1 contract comments to reference TotalApprovedBudget and Delay30Rate
- confirm no remaining references to the old TotalBudget and HighDelayPct names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de603f3fcc8328a37e96d10c3ab794