### PR TITLE
Standardize export filenames and formatting

### DIFF
--- a/tests/test_filenames_and_headers.R
+++ b/tests/test_filenames_and_headers.R
@@ -49,20 +49,13 @@ test_that("output filenames and headers align to spec", {
     report3 <- report_overrun_trends(filtered)
     summary <- build_summary(filtered)
 
-    fmt_opts <- list(
-
-      comma_strings = TRUE,
-      digits = 2,
-      exclude_regex = NULL
-    )
-
     outdir <- file.path(tmp, "outputs")
     dir.create(outdir, showWarnings = FALSE)
 
     paths <- c(
-      write_report1(report1, outdir, fmt_opts),
-      write_report2(report2, outdir, fmt_opts),
-      write_report3(report3, outdir, fmt_opts),
+      write_report1(report1, outdir),
+      write_report2(report2, outdir),
+      write_report3(report3, outdir),
       write_summary_outdir(summary, outdir)
     )
 

--- a/tests/test_io.R
+++ b/tests/test_io.R
@@ -60,13 +60,3 @@ test_that("write_summary_json writes pretty auto-unboxed scalars", {
   })
 })
 
-test_that("write_csv_compat works with current readr", {
-  source("R/io.R")
-  df <- data.frame(a = c(1, 2), b = c('x', 'y'))
-  tmp <- tempfile(fileext = ".csv")
-  on.exit(unlink(tmp), add = TRUE)
-  expect_silent(write_csv_compat(df, file = tmp, na = "", col_names = TRUE, delim = ",", progress = FALSE))
-  back <- readr::read_csv(tmp, show_col_types = FALSE)
-  expect_equal(nrow(back), 2L)
-  expect_true(all(names(back) == c("a","b")))
-})

--- a/tests/test_reports.R
+++ b/tests/test_reports.R
@@ -38,13 +38,6 @@ ensure_outputs_ready <- function() {
   r3 <- report_overrun_trends(df_filtered)
   sumry <- build_summary(df_filtered)
   ensure_outdir("outputs")
-  fmt_opts <- list(
-
-    exclude_regex = NULL,
-    comma_strings = TRUE,
-    digits = 2
-  )
-
 }
 
 ensure_outputs_ready()


### PR DESCRIPTION
## Summary
- update the report path helpers to emit the standardized filenames required by REQ-0010
- ensure write_report_csv applies the shared format_dataframe presentation settings before calling readr::write_csv
- remove the unused formatting overrides from the report writers and refresh related tests

## Testing
- Rscript -e 'testthat::test_dir("tests")' *(fails: Rscript not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de6725b1a08328b0856762397d7db7